### PR TITLE
GitHub Actions本番環境ワークフローのセキュリティと設定の改善

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -8,21 +8,20 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_DB_PASSWORD }}
-      PRODUCTION_PROJECT_ID: owagpoywxhbsckytdtoj
-      GOOGLE_CLIENT_ID: "dummy"
-      GOOGLE_SECRET: "dummy"
-      OPENAI_API_KEY: "dummy"
+      SUPABASE_PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - uses: supabase/setup-cli@v1
+        with:
+          version: latest
 
       - run: |
-          supabase link --project-ref $PRODUCTION_PROJECT_ID
+          supabase link --project-ref $SUPABASE_PROJECT_ID
           supabase db push

--- a/cspell.json
+++ b/cspell.json
@@ -4,7 +4,8 @@
 	"ignorePaths": [
 		"supabase/config.toml",
 		"supabase/migrations",
-		"lib/database.types.ts"
+		"lib/database.types.ts",
+		"package.json"
 	],
 	"words": [
 		"jankiroku",
@@ -19,7 +20,6 @@
 		"Postgrest",
 		"ilike",
 		"Inbucket",
-		"turbopack",
-		"ggkmppnjhrwzdsamzqbp"
+		"turbopack"
 	]
 }


### PR DESCRIPTION
## 概要

GitHub Actionsの本番環境デプロイワークフローのセキュリティと保守性を改善しました。

## 変更内容

### GitHub Actionsワークフロー改善

- ランナーバージョンを`ubuntu-24.04`から`ubuntu-latest`に変更して保守性を向上
- 本番環境のプロジェクトIDをGitHub Secretsに移行してセキュリティを強化
- Supabase CLIのバージョンを明示的に`latest`に指定
- 不要なダミー環境変数を削除（`GOOGLE_CLIENT_ID`、`GOOGLE_SECRET`、`OPENAI_API_KEY`）

### CSpell設定の更新

- `package.json`をスペルチェック対象から除外（依存パッケージ名のノイズを削減）
- 不要なプロジェクト固有の単語を辞書から削除（`ggkmppnjhrwzdsamzqbp`）

## セキュリティ上の改善

- 本番環境のプロジェクトID（`owagpoywxhbsckytdtoj`）をハードコードではなくGitHub Secretsで管理
- 環境変数`SUPABASE_PROJECT_ID`を使用してシークレットを参照

## 追加で必要な設定

PRマージ前に以下のGitHub Secretを設定してください:

```
PRODUCTION_PROJECT_ID = owagpoywxhbsckytdtoj
```

**設定場所**: `Settings` → `Secrets and variables` → `Actions` → `New repository secret`

## テスト

- ✅ Lefthook pre-commit フック通過
- ✅ Lefthook pre-push フック通過（テスト、スペルチェック、型チェック）
- ✅ Biome lint/format チェック通過