### PR TITLE
マイグレーショントリガー作成の冪等性を確保

### DIFF
--- a/supabase/migrations/20251230203218_local.sql
+++ b/supabase/migrations/20251230203218_local.sql
@@ -1,3 +1,6 @@
+-- トリガーが既に存在する場合は削除してから再作成
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
 CREATE TRIGGER on_auth_user_created AFTER INSERT ON auth.users FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
 
 


### PR DESCRIPTION
## 概要

GitHub Actionsでのマイグレーション適用時に発生していたトリガー重複エラーを解決しました。

## 問題

以前、`on_auth_user_created` トリガーがマイグレーションファイルに含まれていなかったため手動で作成していましたが、新しく `supabase:diff` を実行すると同じトリガーがマイグレーションファイルに含まれてしまい、CI/CDパイプラインで以下のエラーが発生していました:

```
ERROR: trigger "on_auth_user_created" for relation "users" already exists (SQLSTATE 42710)
```

## 変更内容

- マイグレーションファイルに `DROP TRIGGER IF EXISTS` を追加
- トリガーを削除してから再作成することで冪等性を確保
- 何度実行しても安全で同じ結果になるように修正

## 影響範囲

- `supabase/migrations/20251230203218_local.sql` のみ

## テスト

- ローカルでの型チェック: ✅
- ユニットテスト: ✅
- CSpellチェック: ✅