### PR TITLE
classnames を tailwind-variants の cn に置き換え

### DIFF
--- a/app/(auth)/login/_components/social-providers/index.tsx
+++ b/app/(auth)/login/_components/social-providers/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import { Button } from "@/components/button";
 import { GoogleIcon } from "@/components/social-provider-icon";
 import { getIsWebview } from "@/lib/utils/userAgent";
@@ -21,7 +21,7 @@ export function SocialProviders({ className }: { className?: string }) {
   };
 
   return (
-    <ul className={classNames("space-y-2", className)}>
+    <ul className={cn("space-y-2", className)}>
       <li className="w-full">
         <Button
           fullWidth

--- a/app/(auth)/register/_components/register-form/index.tsx
+++ b/app/(auth)/register/_components/register-form/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import { useActionState, useId } from "react";
 import { Button } from "@/components/button";
 import { Input } from "@/components/input";
@@ -27,7 +27,7 @@ export function RegisterForm({
 
   return (
     <form
-      className={classNames(className, "space-y-2.5")}
+      className={cn(className, "space-y-2.5")}
       action={formAction}
       noValidate
     >

--- a/app/(auth)/sign-up/_components/sign-up-form/index.tsx
+++ b/app/(auth)/sign-up/_components/sign-up-form/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import { useActionState, useId } from "react";
 import { Button } from "@/components/button";
 import { Input } from "@/components/input";
@@ -16,7 +16,7 @@ export function SignUpForm({ className }: { className?: string }) {
 
   return (
     <form
-      className={classNames("space-y-2.5 py-4", className)}
+      className={cn("space-y-2.5 py-4", className)}
       action={formAction}
       noValidate
     >

--- a/app/(main)/matches/[matchId]/_components/data-modal/chart/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/data-modal/chart/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import {
   Legend,
   Line,
@@ -50,7 +50,7 @@ export function DataChart({
 
   return (
     <div
-      className={classNames(
+      className={cn(
         "h-[300px] w-full rounded-large bg-content1 p-2 shadow-small",
         className,
       )}

--- a/app/(main)/matches/[matchId]/_components/data-modal/summary/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/data-modal/summary/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import {
   Table,
   TableBody,
@@ -25,8 +25,8 @@ export function Summary({ match }: { match: Match }) {
   return (
     <Table
       classNames={{
-        wrapper: classNames("p-0"),
-        th: classNames("bg-inherit"),
+        wrapper: cn("p-0"),
+        th: cn("bg-inherit"),
       }}
     >
       <TableHeader columns={columns}>

--- a/app/(main)/matches/[matchId]/_components/game-modal/form/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/game-modal/form/index.tsx
@@ -3,7 +3,7 @@
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import { SortableContext, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import { useActionState, useCallback, useEffect } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { Button } from "@/components/button";
@@ -138,7 +138,7 @@ export function GameForm({ match }: { match: Match }) {
                               endContent={
                                 <div className="pointer-events-none flex shrink-0 items-center gap-1">
                                   <span
-                                    className={classNames("mt-0.5 text-tiny", {
+                                    className={cn("mt-0.5 text-tiny", {
                                       "text-default-400":
                                         watch(`players.${index}.points`) === "",
                                     })}

--- a/app/(main)/matches/[matchId]/_components/match-table/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/match-table/index.tsx
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import type { CSSProperties } from "react";
 import { Icon } from "@/components/icon";
 import { serverServices } from "@/lib/services/server";
@@ -74,7 +74,7 @@ export async function MatchTable({
   };
 
   return (
-    <div className={classNames(className, "overflow-x-auto pb-4")}>
+    <div className={cn(className, "overflow-x-auto pb-4")}>
       <div className="flex h-full min-w-fit flex-col">
         {/* ヘッダー */}
         <PlayersModalTrigger
@@ -110,7 +110,7 @@ export async function MatchTable({
                 {columns.map((column) => (
                   <div
                     key={column.id}
-                    className={classNames(
+                    className={cn(
                       "flex h-full items-center justify-center break-all px-1 py-2 text-center text-small",
                       {
                         "text-danger": item.players[column.id] < 0,
@@ -141,7 +141,7 @@ export async function MatchTable({
             </div>
             {columns.map((column) => (
               <div
-                className={classNames(
+                className={cn(
                   "flex h-full items-center justify-center px-1 text-center text-tiny",
                   {
                     "text-danger": column.totalScore < 0,

--- a/app/(main)/matches/_components/create-match-button/index.tsx
+++ b/app/(main)/matches/_components/create-match-button/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import { useActionState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { Accordion, AccordionItem } from "@/components/accordion";
@@ -251,7 +251,7 @@ export function CreateMatchButton({ className }: { className?: string }) {
                             name="customIncline.incline4"
                             render={({ field }) => (
                               <Input
-                                className={classNames({
+                                className={cn({
                                   hidden: playersCount === "3",
                                 })}
                                 hidden={playersCount === "3"}

--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import { Righteous, RocknRoll_One } from "next/font/google";
 
 const righteous = Righteous({
@@ -15,7 +15,4 @@ const rocknRollOne = RocknRoll_One({
   display: "swap",
 });
 
-export const fontClassNames = classNames(
-  righteous.variable,
-  rocknRollOne.variable,
-);
+export const fontClassNames = cn(righteous.variable, rocknRollOne.variable);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import type { Metadata } from "next";
 import { IconDefs } from "@/components/icon";
 import { SERVICE_NAME } from "@/lib/config";
@@ -27,7 +27,7 @@ export default function RootLayout({
   return (
     <html
       lang="ja"
-      className={classNames(fontClassNames, "h-full scroll-smooth")}
+      className={cn(fontClassNames, "h-full scroll-smooth")}
       suppressHydrationWarning
     >
       <body className="h-full font-rocknroll">

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -4,7 +4,7 @@
  */
 /** biome-ignore-all lint/correctness/useUniqueElementIds: this is a static icon */
 
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 
 export type IconName =
   | "add"
@@ -41,7 +41,7 @@ export function Icon({
     <svg
       role="img"
       aria-label={name}
-      className={classNames("fill-current", className)}
+      className={cn("fill-current", className)}
       viewBox="0 0 44 44"
       height={size || height || 24}
       width={size || width || 24}

--- a/components/input.tsx
+++ b/components/input.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Input as HeroUiInput, type InputProps } from "@heroui/react";
-import classNames from "classnames";
+import { cn, Input as HeroUiInput, type InputProps } from "@heroui/react";
 import { forwardRef } from "react";
+// import { cn } from "tailwind-variants";
 
 export const Input = forwardRef<
   HTMLInputElement,
@@ -12,7 +12,7 @@ export const Input = forwardRef<
     <HeroUiInput
       classNames={{
         ...propsClassNames,
-        input: classNames("text-medium", propsClassNames?.input), // ios safariで拡大されるのを防ぐ
+        input: cn("text-medium", propsClassNames?.input), // ios safariで拡大されるのを防ぐ
       }}
       {...props}
       ref={ref}

--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -1,12 +1,8 @@
-import classNames from "classnames";
+import { cn } from "@heroui/react";
 import { SERVICE_NAME } from "@/lib/config";
 
 function Logo({ className }: { className?: string }) {
-  return (
-    <div className={classNames("font-rocknroll", className)}>
-      {SERVICE_NAME}
-    </div>
-  );
+  return <div className={cn("font-rocknroll", className)}>{SERVICE_NAME}</div>;
 }
 
 export default Logo;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@hookform/resolvers": "5.2.2",
         "@supabase/ssr": "0.8.0",
         "@supabase/supabase-js": "2.89.0",
-        "classnames": "2.5.1",
         "dayjs": "1.11.19",
         "framer-motion": "12.23.26",
         "next": "16.1.1",
@@ -6716,12 +6715,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
     },
     "node_modules/clear-module": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@hookform/resolvers": "5.2.2",
     "@supabase/ssr": "0.8.0",
     "@supabase/supabase-js": "2.89.0",
-    "classnames": "2.5.1",
     "dayjs": "1.11.19",
     "framer-motion": "12.23.26",
     "next": "16.1.1",


### PR DESCRIPTION
## 概要

`classnames` ライブラリを `@heroui/react` から提供される `cn` ユーティリティ関数に置き換えました。これにより、Tailwind CSS との統合が最適化され、依存関係が削減されます。

## 変更内容

- `classnames` パッケージを `package.json` から削除
- 12個のコンポーネントファイルで `classnames` のインポートを `@heroui/react` の `cn` に置き換え
- すべての `classNames()` の使用箇所を `cn()` に変更
- 既存の機能を維持しながらTailwindとの統合を最適化

### 修正したファイル

- components/icon.tsx
- components/logo.tsx
- components/input.tsx
- app/layout.tsx
- app/fonts.ts
- app/(main)/matches/_components/create-match-button/index.tsx
- app/(main)/matches/[matchId]/_components/match-table/index.tsx
- app/(main)/matches/[matchId]/_components/data-modal/summary/index.tsx
- app/(main)/matches/[matchId]/_components/game-modal/form/index.tsx
- app/(main)/matches/[matchId]/_components/data-modal/chart/index.tsx
- app/(auth)/sign-up/_components/sign-up-form/index.tsx
- app/(auth)/register/_components/register-form/index.tsx
- app/(auth)/login/_components/social-providers/index.tsx

## テスト

- ✅ 型チェック成功 (`npm run type`)
- ✅ リント成功 (`npm run check`)
- ✅ 全テスト成功 (`npm test`)
- ✅ スペルチェック成功 (`npm run spell`)