### PR TITLE
プロフィール編集画面の追加

### DIFF
--- a/app/(main)/_components/appbar/appbar-avatar/appbar-avatar-menu/index.tsx
+++ b/app/(main)/_components/appbar/appbar-avatar/appbar-avatar-menu/index.tsx
@@ -4,17 +4,14 @@ import { Dropdown, type Key, Label } from "@heroui/react";
 import { useRouter } from "next/navigation";
 import { signOut } from "./actions";
 
-export function AppbarAvatarMenu({
-  name,
-  displayId,
-}: {
-  name: string;
-  displayId: string;
-}) {
+export function AppbarAvatarMenu() {
   const router = useRouter();
 
   function handleProfileMenuAction(key: Key) {
     switch (key) {
+      case "editProfile":
+        router.push("/profile");
+        break;
       case "friends":
         // prefetchしたほうが早いかも
         router.push("/friends");
@@ -33,13 +30,8 @@ export function AppbarAvatarMenu({
       aria-label="プロフィール"
       onAction={handleProfileMenuAction}
     >
-      <Dropdown.Item
-        id="profile"
-        className="h-14 gap-2"
-        textValue={`${name}@${displayId}`}
-      >
-        <p className="text-wrap break-all">{name}</p>
-        <p className="text-wrap break-all">@{displayId}</p>
+      <Dropdown.Item id="editProfile">
+        <Label>プロフィール編集</Label>
       </Dropdown.Item>
       <Dropdown.Item id="friends">
         <Label>フレンド</Label>

--- a/app/(main)/_components/appbar/appbar-avatar/index.tsx
+++ b/app/(main)/_components/appbar/appbar-avatar/index.tsx
@@ -23,7 +23,22 @@ export async function AppbarAvatar() {
         </Avatar>
       </Dropdown.Trigger>
       <Dropdown.Popover className="min-w-60">
-        <AppbarAvatarMenu name={profile.name} displayId={profile.displayId} />
+        <div className="px-3 pt-3 pb-1">
+          <div className="flex items-center gap-2">
+            <Avatar size="sm">
+              <Avatar.Fallback>
+                <UserRound />
+              </Avatar.Fallback>
+            </Avatar>
+            <div className="flex flex-col gap-0">
+              <p className="text-sm/5 font-medium">{profile.name}</p>
+              <p className="text-xs leading-none text-muted">
+                @{profile.displayId}
+              </p>
+            </div>
+          </div>
+        </div>
+        <AppbarAvatarMenu />
       </Dropdown.Popover>
     </Dropdown>
   );

--- a/app/(main)/profile/_components/profile-form/actions.ts
+++ b/app/(main)/profile/_components/profile-form/actions.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { parseSubmission, report } from "@conform-to/react/future";
+import { revalidatePath } from "next/cache";
+import { serverServices } from "@/lib/services/server";
+import { updateNameSchema } from "./schema";
+
+export async function updateName(_prevState: unknown, formData: FormData) {
+  const submission = parseSubmission(formData);
+  const result = updateNameSchema.safeParse(submission.payload);
+
+  if (!result.success) {
+    return report(submission, {
+      error: {
+        issues: result.error.issues,
+      },
+    });
+  }
+  const { name } = result.data;
+
+  const { getUserProfile, updateUserProfile } = await serverServices();
+
+  const profile = await getUserProfile();
+  if (!profile.displayId) {
+    return report(submission, {
+      error: { formErrors: ["プロフィールが見つかりません。"] },
+    });
+  }
+
+  const updateResult = await updateUserProfile({
+    name,
+    displayId: profile.displayId,
+  });
+
+  if (!updateResult.success) {
+    throw updateResult.error;
+  }
+
+  revalidatePath("/", "layout");
+  return report(submission, {});
+}

--- a/app/(main)/profile/_components/profile-form/index.tsx
+++ b/app/(main)/profile/_components/profile-form/index.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useForm } from "@conform-to/react/future";
+import {
+  cn,
+  Description,
+  FieldError,
+  Input,
+  Label,
+  TextField,
+  toast,
+} from "@heroui/react";
+import { useActionState } from "react";
+import { Button } from "@/components/button";
+import { Form } from "@/components/form";
+import { NAME_MAX_LENGTH } from "@/lib/config";
+import type { Profile } from "@/lib/type";
+import { createSubmitHandler, withCallbacks } from "@/lib/utils/form";
+import { updateName } from "./actions";
+import { updateNameSchema } from "./schema";
+
+export function ProfileForm({
+  className,
+  profile,
+}: {
+  className?: string;
+  profile: Profile;
+}) {
+  const [lastResult, formAction, isPending] = useActionState(
+    withCallbacks(updateName, {
+      onSuccess() {
+        toast.success("プロフィールを更新しました");
+      },
+    }),
+    null,
+  );
+  const { form, fields } = useForm(updateNameSchema, {
+    lastResult,
+    defaultValue: { name: profile.name ?? "" },
+    onSubmit: createSubmitHandler(formAction),
+  });
+
+  return (
+    <Form
+      className={cn(className, "space-y-4")}
+      validationErrors={form.fieldErrors}
+      {...form.props}
+    >
+      <div className="space-y-4">
+        <TextField name="displayId" isReadOnly isDisabled>
+          <Label>ユーザーID</Label>
+          <Input value={profile.displayId ?? ""} />
+          <Description>ユーザーIDは変更できません</Description>
+        </TextField>
+        <TextField
+          name={fields.name.name}
+          defaultValue={fields.name.defaultValue}
+          autoComplete="name"
+        >
+          <Label>名前</Label>
+          <Input />
+          <Description>{`${NAME_MAX_LENGTH}文字以内で入力してください`}</Description>
+          <FieldError />
+        </TextField>
+      </div>
+      <div className="flex justify-end">
+        <Button variant="primary" type="submit" isPending={isPending}>
+          保存
+        </Button>
+      </div>
+    </Form>
+  );
+}

--- a/app/(main)/profile/_components/profile-form/schema.ts
+++ b/app/(main)/profile/_components/profile-form/schema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+import { schema } from "@/lib/utils/schema";
+
+export const updateNameSchema = z.object({
+  name: schema.name,
+});

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { serverServices } from "@/lib/services/server";
+import { ProfileForm } from "./_components/profile-form";
+
+export const metadata: Metadata = {
+  title: "プロフィール編集",
+};
+
+export default async function ProfilePage() {
+  const { getUserProfile } = await serverServices();
+  const profile = await getUserProfile();
+
+  if (profile.isUnregistered) {
+    redirect("/register");
+  }
+
+  return (
+    <div className="mx-auto max-w-md">
+      <h1 className="mx-auto mb-4 w-fit text-lg">プロフィール編集</h1>
+      <ProfileForm profile={profile} />
+    </div>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { Toast } from "@heroui/react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <NextThemesProvider attribute="class" defaultTheme="system">
       {children}
+      <Toast.Provider />
     </NextThemesProvider>
   );
 }


### PR DESCRIPTION
## 概要

登録後にプロフィールを編集できる画面を追加しました。displayIdは変更不可ポリシーとし、名前のみ変更できます。

## 変更内容

- `/profile` ページを新規追加（AppBarのアバターメニューから遷移）
- プロフィール編集フォームを実装（名前のみ編集可、displayIdは読み取り専用で表示）
- AppBarのアバターメニューに「プロフィール編集」項目を追加
- アバターメニューのプロフィール表示をServer Component側に移動（`appbar-avatar/index.tsx`）
- `Toast.Provider` を `providers.tsx` に追加し、保存成功時のトースト通知に対応