### PR TITLE
プロフィール画像のアップロード機能を追加

### DIFF
--- a/app/(auth)/register/_components/register-form/actions.ts
+++ b/app/(auth)/register/_components/register-form/actions.ts
@@ -7,7 +7,11 @@ import { serverServices } from "@/lib/services/server";
 import { createClient } from "@/lib/supabase/server";
 import { updateProfileSchema } from "./schema";
 
-export async function updateProfile(_prevState: unknown, formData: FormData) {
+export async function updateProfile(
+  avatarUrl: string | undefined,
+  _prevState: unknown,
+  formData: FormData,
+) {
   const submission = parseSubmission(formData);
   const result = updateProfileSchema.safeParse(submission.payload);
 
@@ -32,6 +36,7 @@ export async function updateProfile(_prevState: unknown, formData: FormData) {
   const updateResult = await updateUserProfile({
     name,
     displayId,
+    avatarUrl,
   });
 
   if (!updateResult.success) {

--- a/app/(auth)/register/_components/register-form/index.tsx
+++ b/app/(auth)/register/_components/register-form/index.tsx
@@ -10,7 +10,8 @@ import {
   Label,
   TextField,
 } from "@heroui/react";
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
+import { AvatarInput } from "@/components/avatar-input";
 import { Button } from "@/components/button";
 import { Form } from "@/components/form";
 import {
@@ -29,8 +30,11 @@ export function RegisterForm({
   className?: string;
   userId: string;
 }) {
+  const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
+  const [isAvatarUploading, setIsAvatarUploading] = useState(false);
+
   const [lastResult, formAction, isPending] = useActionState(
-    updateProfile,
+    updateProfile.bind(null, avatarUrl),
     null,
   );
   const { form, fields } = useForm(updateProfileSchema, {
@@ -45,6 +49,12 @@ export function RegisterForm({
       {...form.props}
     >
       <input type="hidden" name="userId" value={userId} />
+      <div className="flex justify-center">
+        <AvatarInput
+          onUpload={setAvatarUrl}
+          onUploadingChange={setIsAvatarUploading}
+        />
+      </div>
       <div className="space-y-4">
         <TextField name={fields.displayId.name}>
           <Label>ユーザーID</Label>
@@ -61,7 +71,12 @@ export function RegisterForm({
       </div>
       {form.errors && <ErrorMessage>{form.errors}</ErrorMessage>}
       <div className="flex justify-end">
-        <Button variant="primary" type="submit" isPending={isPending}>
+        <Button
+          variant="primary"
+          type="submit"
+          isPending={isPending}
+          isDisabled={isAvatarUploading}
+        >
           決定
         </Button>
       </div>

--- a/app/(main)/_components/appbar/appbar-avatar/index.tsx
+++ b/app/(main)/_components/appbar/appbar-avatar/index.tsx
@@ -1,9 +1,12 @@
-import { Avatar, Dropdown } from "@heroui/react";
-import { UserRound } from "lucide-react";
+import { Dropdown } from "@heroui/react";
 import { redirect } from "next/navigation";
+import { UserAvatar } from "@/components/user-avatar";
 import { serverServices } from "@/lib/services/server";
 import { AppbarAvatarMenu } from "./appbar-avatar-menu";
 
+/**
+ * @see https://heroui.com/docs/react/components/dropdown#custom-trigger
+ */
 export async function AppbarAvatar() {
   const { getUserProfile } = await serverServices();
   const [profile] = await Promise.all([getUserProfile()]);
@@ -15,29 +18,17 @@ export async function AppbarAvatar() {
 
   return (
     <Dropdown>
-      <Dropdown.Trigger aria-label="プロフィールメニュー">
-        <Avatar className="transition-transform" size="sm">
-          {profile.avatarUrl ? (
-            <Avatar.Image src={profile.avatarUrl} alt="プロフィール画像" />
-          ) : (
-            <Avatar.Fallback>
-              <UserRound />
-            </Avatar.Fallback>
-          )}
-        </Avatar>
+      <Dropdown.Trigger className="rounded-full">
+        <UserAvatar
+          avatarUrl={profile.avatarUrl}
+          name={profile.name}
+          size="sm"
+        />
       </Dropdown.Trigger>
       <Dropdown.Popover className="min-w-60">
         <div className="px-3 pt-3 pb-1">
           <div className="flex items-center gap-2">
-            <Avatar size="sm">
-              {profile.avatarUrl ? (
-                <Avatar.Image src={profile.avatarUrl} alt="プロフィール画像" />
-              ) : (
-                <Avatar.Fallback>
-                  <UserRound />
-                </Avatar.Fallback>
-              )}
-            </Avatar>
+            <UserAvatar avatarUrl={profile.avatarUrl} name={profile.name} />
             <div className="flex flex-col gap-0">
               <p className="text-sm/5 font-medium">{profile.name}</p>
               <p className="text-xs leading-none text-muted">

--- a/app/(main)/_components/appbar/appbar-avatar/index.tsx
+++ b/app/(main)/_components/appbar/appbar-avatar/index.tsx
@@ -17,18 +17,26 @@ export async function AppbarAvatar() {
     <Dropdown>
       <Dropdown.Trigger aria-label="プロフィールメニュー">
         <Avatar className="transition-transform" size="sm">
-          <Avatar.Fallback>
-            <UserRound />
-          </Avatar.Fallback>
+          {profile.avatarUrl ? (
+            <Avatar.Image src={profile.avatarUrl} alt="プロフィール画像" />
+          ) : (
+            <Avatar.Fallback>
+              <UserRound />
+            </Avatar.Fallback>
+          )}
         </Avatar>
       </Dropdown.Trigger>
       <Dropdown.Popover className="min-w-60">
         <div className="px-3 pt-3 pb-1">
           <div className="flex items-center gap-2">
             <Avatar size="sm">
-              <Avatar.Fallback>
-                <UserRound />
-              </Avatar.Fallback>
+              {profile.avatarUrl ? (
+                <Avatar.Image src={profile.avatarUrl} alt="プロフィール画像" />
+              ) : (
+                <Avatar.Fallback>
+                  <UserRound />
+                </Avatar.Fallback>
+              )}
             </Avatar>
             <div className="flex flex-col gap-0">
               <p className="text-sm/5 font-medium">{profile.name}</p>

--- a/app/(main)/friends/add/page.tsx
+++ b/app/(main)/friends/add/page.tsx
@@ -30,9 +30,9 @@ export default async function AddFriendPage({
             見つかりませんでした
           </p>
         )}
-        {profiles.map(({ id, name, displayId, isFriend }) => (
+        {profiles.map(({ id, name, displayId, avatarUrl, isFriend }) => (
           <li key={id} className="flex items-center justify-between py-2">
-            <User name={name} displayId={displayId} />
+            <User name={name} displayId={displayId} avatarUrl={avatarUrl} />
             {isFriend ? (
               <div className="w-16 text-center text-xs text-muted">
                 追加済み

--- a/app/(main)/friends/loading.tsx
+++ b/app/(main)/friends/loading.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/components/user";
+import { UserSkeleton } from "@/components/user";
 
 export default function FriendsLoading() {
   return (
@@ -9,7 +9,7 @@ export default function FriendsLoading() {
       <ul className="space-y-1">
         {Array.from({ length: 3 }, (_, i) => `skeleton-${i}`).map((id) => (
           <li className="flex items-center justify-between py-2" key={id}>
-            <User skeleton />
+            <UserSkeleton />
           </li>
         ))}
       </ul>

--- a/app/(main)/friends/page.tsx
+++ b/app/(main)/friends/page.tsx
@@ -20,7 +20,11 @@ export default async function FriendsPage() {
             className="flex items-center justify-between py-1"
             key={friend.id}
           >
-            <User name={friend.name} displayId={friend.displayId} />
+            <User
+              name={friend.name}
+              displayId={friend.displayId}
+              avatarUrl={friend.avatarUrl}
+            />
             <FriendMenu profileId={friend.id} />
           </li>
         ))}

--- a/app/(main)/matches/[matchId]/_components/match-table/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/match-table/index.tsx
@@ -48,6 +48,7 @@ export async function MatchTable({
           id: `player-${i}`,
           displayId: "",
           name: "",
+          avatarUrl: null,
           type: "empty",
           rankCounts: [0] as number[],
           averageRank: null,

--- a/app/(main)/matches/_components/match-card/index.tsx
+++ b/app/(main)/matches/_components/match-card/index.tsx
@@ -1,6 +1,6 @@
-import { Avatar, Card, cardVariants, Separator } from "@heroui/react";
-import { UserRound } from "lucide-react";
+import { Card, cardVariants, Separator } from "@heroui/react";
 import NextLink from "next/link";
+import { UserAvatar } from "@/components/user-avatar";
 import type { Match } from "@/lib/type";
 import { dayjs } from "@/lib/utils/date";
 
@@ -29,11 +29,12 @@ export function MatchCard({ match, userId }: { match: Match; userId: string }) {
             "
           >
             {match.players.map((player) => (
-              <Avatar key={player.id} size="sm">
-                <Avatar.Fallback>
-                  <UserRound />
-                </Avatar.Fallback>
-              </Avatar>
+              <UserAvatar
+                key={player.id}
+                avatarUrl={player.avatarUrl}
+                name={player.name}
+                size="sm"
+              />
             ))}
           </div>
         </div>

--- a/app/(main)/matches/_components/player-selector/index.tsx
+++ b/app/(main)/matches/_components/player-selector/index.tsx
@@ -10,9 +10,10 @@ import {
   ScrollShadow,
   SearchField,
 } from "@heroui/react";
-import { Check, PlusIcon, User as UserIcon } from "lucide-react";
+import { Check, PlusIcon } from "lucide-react";
 import { useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
+import { UserAvatar } from "@/components/user-avatar";
 import type { Profile } from "@/lib/type";
 
 function PlayerListBoxItem({
@@ -24,11 +25,7 @@ function PlayerListBoxItem({
 }) {
   return (
     <ListBox.Item id={player.id}>
-      <Avatar size="sm">
-        <Avatar.Fallback>
-          <UserIcon />
-        </Avatar.Fallback>
-      </Avatar>
+      <UserAvatar avatarUrl={player.avatarUrl} name={player.name} size="sm" />
       <div className="flex flex-col">
         <div className="flex items-center gap-1">
           <Label>{player.name}</Label>
@@ -116,11 +113,11 @@ export function PlayerSelector({
                   "
                 >
                   <div className="relative w-fit">
-                    <Avatar size="md">
-                      <Avatar.Fallback>
-                        <UserIcon />
-                      </Avatar.Fallback>
-                    </Avatar>
+                    <UserAvatar
+                      avatarUrl={player.avatarUrl}
+                      name={player.name}
+                      size="md"
+                    />
                     {!disabledPlayerIds.includes(player.id) && (
                       <CloseButton
                         className="

--- a/app/(main)/profile/_components/profile-form/actions.ts
+++ b/app/(main)/profile/_components/profile-form/actions.ts
@@ -3,11 +3,11 @@
 import { parseSubmission, report } from "@conform-to/react/future";
 import { revalidatePath } from "next/cache";
 import { serverServices } from "@/lib/services/server";
-import { updateNameSchema } from "./schema";
+import { profileUpdateSchema } from "./schema";
 
-export async function updateName(_prevState: unknown, formData: FormData) {
+export async function updateProfile(_prevState: unknown, formData: FormData) {
   const submission = parseSubmission(formData);
-  const result = updateNameSchema.safeParse(submission.payload);
+  const result = profileUpdateSchema.safeParse(submission.payload);
 
   if (!result.success) {
     return report(submission, {
@@ -16,7 +16,7 @@ export async function updateName(_prevState: unknown, formData: FormData) {
       },
     });
   }
-  const { name } = result.data;
+  const { name, avatarUrl } = result.data;
 
   const { getUserProfile, updateUserProfile } = await serverServices();
 
@@ -30,6 +30,7 @@ export async function updateName(_prevState: unknown, formData: FormData) {
   const updateResult = await updateUserProfile({
     name,
     displayId: profile.displayId,
+    avatarUrl,
   });
 
   if (!updateResult.success) {

--- a/app/(main)/profile/_components/profile-form/actions.ts
+++ b/app/(main)/profile/_components/profile-form/actions.ts
@@ -5,7 +5,14 @@ import { revalidatePath } from "next/cache";
 import { serverServices } from "@/lib/services/server";
 import { profileUpdateSchema } from "./schema";
 
-export async function updateProfile(_prevState: unknown, formData: FormData) {
+export async function updateProfile(
+  // avatarUrlはformDataではなく.bind()で渡す。
+  // Next.jsはbindされた引数をサーバー側で暗号化するため、
+  // クライアントからの読み取り・改ざんが不可能。
+  avatarUrl: string | undefined,
+  _prevState: unknown,
+  formData: FormData,
+) {
   const submission = parseSubmission(formData);
   const result = profileUpdateSchema.safeParse(submission.payload);
 
@@ -16,7 +23,7 @@ export async function updateProfile(_prevState: unknown, formData: FormData) {
       },
     });
   }
-  const { name, avatarUrl } = result.data;
+  const { name } = result.data;
 
   const { getUserProfile, updateUserProfile } = await serverServices();
 

--- a/app/(main)/profile/_components/profile-form/index.tsx
+++ b/app/(main)/profile/_components/profile-form/index.tsx
@@ -39,7 +39,10 @@ export function ProfileForm({
 
   const { form, fields } = useForm(profileUpdateSchema, {
     lastResult,
-    defaultValue: { name: profile.name ?? "", avatarUrl: profile.avatarUrl },
+    defaultValue: {
+      name: profile.name ?? "",
+      avatarUrl: profile.avatarUrl ?? undefined,
+    },
     onSubmit: createSubmitHandler(formAction),
   });
 

--- a/app/(main)/profile/_components/profile-form/index.tsx
+++ b/app/(main)/profile/_components/profile-form/index.tsx
@@ -27,22 +27,25 @@ export function ProfileForm({
   className?: string;
   profile: Profile;
 }) {
+  // avatarUrlはformDataに含めず.bind()でserver actionに渡す。
+  // Next.jsはbind引数をサーバー側で暗号化するため、クライアントからの改ざんが不可能。
+  const [avatarUrl, setAvatarUrl] = useState<string | undefined>(
+    profile.avatarUrl ?? undefined,
+  );
+  const [isAvatarUploading, setIsAvatarUploading] = useState(false);
+
   const [lastResult, formAction, isPending] = useActionState(
-    withCallbacks(updateProfile, {
+    withCallbacks(updateProfile.bind(null, avatarUrl), {
       onSuccess() {
         toast.success("プロフィールを更新しました");
       },
     }),
     null,
   );
-  const [isAvatarUploading, setIsAvatarUploading] = useState(false);
 
   const { form, fields } = useForm(profileUpdateSchema, {
     lastResult,
-    defaultValue: {
-      name: profile.name ?? "",
-      avatarUrl: profile.avatarUrl ?? undefined,
-    },
+    defaultValue: { name: profile.name ?? "" },
     onSubmit: createSubmitHandler(formAction),
   });
 
@@ -54,8 +57,8 @@ export function ProfileForm({
     >
       <div className="flex justify-center">
         <AvatarInput
-          name={fields.avatarUrl.name}
-          defaultValue={fields.avatarUrl.defaultValue}
+          defaultValue={profile.avatarUrl ?? undefined}
+          onUpload={setAvatarUrl}
           onUploadingChange={setIsAvatarUploading}
         />
       </div>

--- a/app/(main)/profile/_components/profile-form/index.tsx
+++ b/app/(main)/profile/_components/profile-form/index.tsx
@@ -10,14 +10,15 @@ import {
   TextField,
   toast,
 } from "@heroui/react";
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
+import { AvatarInput } from "@/components/avatar-input";
 import { Button } from "@/components/button";
 import { Form } from "@/components/form";
 import { NAME_MAX_LENGTH } from "@/lib/config";
 import type { Profile } from "@/lib/type";
 import { createSubmitHandler, withCallbacks } from "@/lib/utils/form";
-import { updateName } from "./actions";
-import { updateNameSchema } from "./schema";
+import { updateProfile } from "./actions";
+import { profileUpdateSchema } from "./schema";
 
 export function ProfileForm({
   className,
@@ -27,16 +28,18 @@ export function ProfileForm({
   profile: Profile;
 }) {
   const [lastResult, formAction, isPending] = useActionState(
-    withCallbacks(updateName, {
+    withCallbacks(updateProfile, {
       onSuccess() {
         toast.success("プロフィールを更新しました");
       },
     }),
     null,
   );
-  const { form, fields } = useForm(updateNameSchema, {
+  const [isAvatarUploading, setIsAvatarUploading] = useState(false);
+
+  const { form, fields } = useForm(profileUpdateSchema, {
     lastResult,
-    defaultValue: { name: profile.name ?? "" },
+    defaultValue: { name: profile.name ?? "", avatarUrl: profile.avatarUrl },
     onSubmit: createSubmitHandler(formAction),
   });
 
@@ -46,6 +49,13 @@ export function ProfileForm({
       validationErrors={form.fieldErrors}
       {...form.props}
     >
+      <div className="flex justify-center">
+        <AvatarInput
+          name={fields.avatarUrl.name}
+          defaultValue={fields.avatarUrl.defaultValue}
+          onUploadingChange={setIsAvatarUploading}
+        />
+      </div>
       <div className="space-y-4">
         <TextField name="displayId" isReadOnly isDisabled>
           <Label>ユーザーID</Label>
@@ -64,7 +74,12 @@ export function ProfileForm({
         </TextField>
       </div>
       <div className="flex justify-end">
-        <Button variant="primary" type="submit" isPending={isPending}>
+        <Button
+          variant="primary"
+          type="submit"
+          isPending={isPending}
+          isDisabled={isAvatarUploading}
+        >
           保存
         </Button>
       </div>

--- a/app/(main)/profile/_components/profile-form/schema.ts
+++ b/app/(main)/profile/_components/profile-form/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
-export const updateNameSchema = z.object({
+export const profileUpdateSchema = z.object({
   name: schema.name,
+  avatarUrl: z.string().optional(),
 });

--- a/app/(main)/profile/_components/profile-form/schema.ts
+++ b/app/(main)/profile/_components/profile-form/schema.ts
@@ -3,8 +3,4 @@ import { schema } from "@/lib/utils/schema";
 
 export const profileUpdateSchema = z.object({
   name: schema.name,
-  avatarUrl: z.preprocess(
-    (value) => (value === "" ? undefined : value),
-    z.url().optional(),
-  ),
 });

--- a/app/(main)/profile/_components/profile-form/schema.ts
+++ b/app/(main)/profile/_components/profile-form/schema.ts
@@ -3,5 +3,8 @@ import { schema } from "@/lib/utils/schema";
 
 export const profileUpdateSchema = z.object({
   name: schema.name,
-  avatarUrl: z.string().optional(),
+  avatarUrl: z.preprocess(
+    (value) => (value === "" ? undefined : value),
+    z.url().optional(),
+  ),
 });

--- a/components/avatar-input.tsx
+++ b/components/avatar-input.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Avatar, toast } from "@heroui/react";
+import { CameraIcon, EditIcon } from "lucide-react";
+import { useRef, useState } from "react";
+import { AVATAR_ALLOWED_TYPES, AVATAR_MAX_SIZE } from "@/lib/config";
+import { browserServices } from "@/lib/services/browser";
+
+type AvatarInputProps = {
+  name: string;
+  defaultValue?: string;
+  onUploadingChange?: (isUploading: boolean) => void;
+};
+
+/**
+ * ファイル選択時に即座に Supabase Storage へアップロードし、
+ * 取得した公開 URL を hidden input で保持するコンポーネント。
+ *
+ * アップロードはフォーム送信前に完了するが、設計上問題ない。
+ * アバターのファイルパスは `{uid}/avatar.{ext}` 固定で upsert するため、
+ * 保存せずにページを離脱しても孤立ファイルは最大 1 ファイル/ユーザーに留まり、
+ * 次回アップロード時に自動的に上書きされる。
+ */
+export function AvatarInput({
+  name,
+  defaultValue,
+  onUploadingChange,
+}: AvatarInputProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [previewUrl, setPreviewUrl] = useState(defaultValue);
+  const [uploadedUrl, setUploadedUrl] = useState(defaultValue);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (
+      !AVATAR_ALLOWED_TYPES.includes(
+        file.type as (typeof AVATAR_ALLOWED_TYPES)[number],
+      )
+    ) {
+      toast.danger("jpg、png、webp形式の画像を選択してください");
+      return;
+    }
+    if (file.size > AVATAR_MAX_SIZE) {
+      toast.danger("画像のサイズは2MB以内にしてください");
+      return;
+    }
+
+    setPreviewUrl(URL.createObjectURL(file));
+    setIsUploading(true);
+    onUploadingChange?.(true);
+    try {
+      const { uploadAvatar } = browserServices();
+      const avatarUrl = await uploadAvatar(file);
+      setUploadedUrl(avatarUrl);
+    } catch {
+      toast.danger("画像のアップロードに失敗しました");
+      setPreviewUrl(defaultValue);
+    } finally {
+      setIsUploading(false);
+      onUploadingChange?.(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={isUploading}
+        aria-label="プロフィール画像を変更"
+        className="relative"
+      >
+        <Avatar className="size-20">
+          {previewUrl ? (
+            <Avatar.Image src={previewUrl} alt="プロフィール画像" />
+          ) : (
+            <Avatar.Fallback>
+              <CameraIcon className="size-6" />
+            </Avatar.Fallback>
+          )}
+        </Avatar>
+        {previewUrl && (
+          <div className="absolute right-0 bottom-0 rounded-full bg-default p-1">
+            <EditIcon className="size-4" />
+          </div>
+        )}
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={AVATAR_ALLOWED_TYPES.join(",")}
+        className="sr-only"
+        onChange={handleFileChange}
+      />
+      <input type="hidden" name={name} value={uploadedUrl ?? ""} />
+    </div>
+  );
+}

--- a/components/avatar-input.tsx
+++ b/components/avatar-input.tsx
@@ -48,10 +48,12 @@ export function AvatarInput({
       )
     ) {
       toast.danger("jpg、png、webp形式の画像を選択してください");
+      e.currentTarget.value = "";
       return;
     }
     if (file.size > AVATAR_MAX_SIZE) {
       toast.danger("画像のサイズは2MB以内にしてください");
+      e.currentTarget.value = "";
       return;
     }
 

--- a/components/avatar-input.tsx
+++ b/components/avatar-input.tsx
@@ -7,29 +7,28 @@ import { AVATAR_ALLOWED_TYPES, AVATAR_MAX_SIZE } from "@/lib/config";
 import { browserServices } from "@/lib/services/browser";
 
 type AvatarInputProps = {
-  name: string;
   defaultValue?: string;
+  onUpload?: (url: string) => void;
   onUploadingChange?: (isUploading: boolean) => void;
 };
 
 /**
  * ファイル選択時に即座に Supabase Storage へアップロードし、
- * 取得した公開 URL を hidden input で保持するコンポーネント。
+ * 取得した公開 URL を onUpload コールバックで親に通知するコンポーネント。
  *
  * アップロードはフォーム送信前に完了するが、設計上問題ない。
- * アバターのファイルパスは `{uid}/avatar.{ext}` 固定で upsert するため、
+ * アバターのファイルパスは `{uid}/avatar` 固定で upsert するため、
  * 保存せずにページを離脱しても孤立ファイルは最大 1 ファイル/ユーザーに留まり、
  * 次回アップロード時に自動的に上書きされる。
  */
 export function AvatarInput({
-  name,
   defaultValue,
+  onUpload,
   onUploadingChange,
 }: AvatarInputProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [previewUrl, setPreviewUrl] = useState<string>();
+  const [previewUrl, setPreviewUrl] = useState<string | undefined>(undefined);
   const displayUrl = previewUrl ?? defaultValue;
-  const [uploadedUrl, setUploadedUrl] = useState(defaultValue);
   const [isUploading, setIsUploading] = useState(false);
 
   useEffect(() => {
@@ -62,7 +61,7 @@ export function AvatarInput({
     try {
       const { uploadAvatar } = browserServices();
       const avatarUrl = await uploadAvatar(file);
-      setUploadedUrl(avatarUrl);
+      onUpload?.(avatarUrl);
     } catch {
       toast.danger("画像のアップロードに失敗しました");
       setPreviewUrl(undefined);
@@ -103,7 +102,6 @@ export function AvatarInput({
         className="sr-only"
         onChange={handleFileChange}
       />
-      <input type="hidden" name={name} value={uploadedUrl ?? ""} />
     </div>
   );
 }

--- a/components/avatar-input.tsx
+++ b/components/avatar-input.tsx
@@ -2,7 +2,7 @@
 
 import { Avatar, toast } from "@heroui/react";
 import { CameraIcon, EditIcon } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AVATAR_ALLOWED_TYPES, AVATAR_MAX_SIZE } from "@/lib/config";
 import { browserServices } from "@/lib/services/browser";
 
@@ -27,9 +27,17 @@ export function AvatarInput({
   onUploadingChange,
 }: AvatarInputProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [previewUrl, setPreviewUrl] = useState(defaultValue);
+  const [previewUrl, setPreviewUrl] = useState<string>();
+  const displayUrl = previewUrl ?? defaultValue;
   const [uploadedUrl, setUploadedUrl] = useState(defaultValue);
   const [isUploading, setIsUploading] = useState(false);
+
+  useEffect(() => {
+    if (!previewUrl) return;
+    return () => {
+      URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -57,7 +65,7 @@ export function AvatarInput({
       setUploadedUrl(avatarUrl);
     } catch {
       toast.danger("画像のアップロードに失敗しました");
-      setPreviewUrl(defaultValue);
+      setPreviewUrl(undefined);
     } finally {
       setIsUploading(false);
       onUploadingChange?.(false);
@@ -74,15 +82,15 @@ export function AvatarInput({
         className="relative"
       >
         <Avatar className="size-20">
-          {previewUrl ? (
-            <Avatar.Image src={previewUrl} alt="プロフィール画像" />
+          {displayUrl ? (
+            <Avatar.Image src={displayUrl} alt="プロフィール画像" />
           ) : (
             <Avatar.Fallback>
               <CameraIcon className="size-6" />
             </Avatar.Fallback>
           )}
         </Avatar>
-        {previewUrl && (
+        {displayUrl && (
           <div className="absolute right-0 bottom-0 rounded-full bg-default p-1">
             <EditIcon className="size-4" />
           </div>

--- a/components/user-avatar.tsx
+++ b/components/user-avatar.tsx
@@ -1,0 +1,23 @@
+import { Avatar, type AvatarProps } from "@heroui/react";
+import { UserRound } from "lucide-react";
+
+export function UserAvatar({
+  avatarUrl,
+  name,
+  ...avatarProps
+}: {
+  avatarUrl: string | null;
+  name: string | null;
+} & AvatarProps) {
+  return (
+    <Avatar {...avatarProps}>
+      {avatarUrl ? (
+        <Avatar.Image src={avatarUrl} alt={name ?? "匿名ユーザー"} />
+      ) : (
+        <Avatar.Fallback>
+          <UserRound />
+        </Avatar.Fallback>
+      )}
+    </Avatar>
+  );
+}

--- a/components/user.tsx
+++ b/components/user.tsx
@@ -1,90 +1,39 @@
-import { Avatar, type AvatarProps, cn, Skeleton } from "@heroui/react";
-import { UserRound } from "lucide-react";
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import { cn, Skeleton } from "@heroui/react";
+import type { ComponentPropsWithoutRef } from "react";
+import { UserAvatar } from "./user-avatar";
 
 export type UserProps = ComponentPropsWithoutRef<"div"> & {
-  name?: string | null;
-  displayId?: string | null;
-  skeleton?: boolean;
-  avatarProps?: AvatarProps;
-  classNames?: {
-    base?: string;
-    wrapper?: string;
-    name?: string;
-    description?: string;
-  };
+  name: string | null;
+  displayId: string | null;
+  avatarUrl: string | null;
 };
 
-export const User = forwardRef<HTMLDivElement, UserProps>(
-  (
-    {
-      name,
-      displayId,
-      skeleton,
-      avatarProps,
-      className,
-      classNames,
-      ...restProps
-    },
-    ref,
-  ) => {
-    if (skeleton) {
-      return (
-        <div
-          ref={ref}
-          className={cn(
-            "inline-flex items-center justify-center gap-2 rounded-sm",
-            className,
-          )}
-        >
-          <Skeleton className="size-10 rounded-full" />
-          <div className="inline-flex flex-col items-start gap-1">
-            <Skeleton className="h-4 w-20 rounded-lg" />
-            <Skeleton className="h-3 w-24 rounded-lg" />
-          </div>
-        </div>
-      );
-    }
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          `
-            inline-flex items-center justify-center gap-2 rounded-sm
-            outline-transparent outline-solid
-          `,
-          `
-            data-[focus-visible=true]:z-10 data-[focus-visible=true]:outline-2
-            data-[focus-visible=true]:outline-offset-2
-            data-[focus-visible=true]:outline-focus
-          `,
-          classNames?.base,
-          className,
-        )}
-        {...restProps}
-      >
-        <Avatar {...avatarProps}>
-          <Avatar.Fallback>
-            <UserRound />
-          </Avatar.Fallback>
-        </Avatar>
-        <div
-          className={cn(
-            "inline-flex flex-col items-start",
-            classNames?.wrapper,
-          )}
-        >
-          <span className={cn("text-sm text-inherit", classNames?.name)}>
-            {name}
-          </span>
-          {displayId && (
-            <span className={cn("text-xs text-muted", classNames?.description)}>
-              @{displayId}
-            </span>
-          )}
-        </div>
+export function User({ name, displayId, avatarUrl, className }: UserProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-2 rounded-sm",
+        className,
+      )}
+    >
+      <UserAvatar avatarUrl={avatarUrl} name={name} />
+      <div className="flex flex-col items-start">
+        <span className="text-sm text-inherit">{name}</span>
+        {displayId && <span className="text-xs text-muted">@{displayId}</span>}
       </div>
-    );
-  },
-);
-User.displayName = "User";
+    </div>
+  );
+}
+
+// TODO: Userと高さを合わせる
+export function UserSkeleton() {
+  return (
+    <div className="flex items-center justify-center gap-2 rounded-sm">
+      <Skeleton className="size-10 rounded-full" />
+      <div className="flex-1 space-y-2">
+        <Skeleton className="h-3 w-36 rounded-lg" />
+        <Skeleton className="h-3 w-24 rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,12 @@
 export const SERVICE_NAME = "雀鬼録";
 export const PASSWORD_MIN_LENGTH = 6;
 export const NAME_MAX_LENGTH = 12;
+export const AVATAR_MAX_SIZE = 2 * 1024 * 1024;
+export const AVATAR_ALLOWED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
 export const DISPLAY_ID_MIN_LENGTH = 4;
 export const DISPLAY_ID_MAX_LENGTH = 12;
 

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -12,31 +12,6 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.1";
   };
-  graphql_public: {
-    Tables: {
-      [_ in never]: never;
-    };
-    Views: {
-      [_ in never]: never;
-    };
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json;
-          operationName?: string;
-          query?: string;
-          variables?: Json;
-        };
-        Returns: Json;
-      };
-    };
-    Enums: {
-      [_ in never]: never;
-    };
-    CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
   public: {
     Tables: {
       friends: {
@@ -205,16 +180,19 @@ export type Database = {
       };
       profiles: {
         Row: {
+          avatar_url: string | null;
           display_id: string | null;
           id: string;
           name: string | null;
         };
         Insert: {
+          avatar_url?: string | null;
           display_id?: string | null;
           id?: string;
           name?: string | null;
         };
         Update: {
+          avatar_url?: string | null;
           display_id?: string | null;
           id?: string;
           name?: string | null;
@@ -431,9 +409,6 @@ export type CompositeTypes<
     : never;
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {},
   },

--- a/lib/services/features/friend.ts
+++ b/lib/services/features/friend.ts
@@ -19,6 +19,7 @@ export const friendService = (supabase: Supabase) => {
         id: friend.profiles.id,
         name: friend.profiles.name,
         displayId: friend.profiles.display_id,
+        avatarUrl: friend.profiles.avatar_url,
         isFriend: true,
       }));
     },

--- a/lib/services/features/match.ts
+++ b/lib/services/features/match.ts
@@ -196,6 +196,7 @@ const formatMatch = (match: {
       id: string;
       name: string | null;
       display_id: string | null;
+      avatar_url: string | null;
     };
     chip_count: number | null;
   }[];
@@ -227,6 +228,7 @@ const formatMatch = (match: {
       id: profiles.id,
       name: profiles.name,
       displayId: profiles.display_id,
+      avatarUrl: profiles.avatar_url,
       rankCounts: new Array(rule.players_count).fill(0),
       averageRank: null,
       totalScore: 0,

--- a/lib/services/features/profile.ts
+++ b/lib/services/features/profile.ts
@@ -28,6 +28,7 @@ export const profileService = (supabase: Supabase) => {
           id: user.id,
           name: null,
           displayId: null,
+          avatarUrl: null,
           isUnregistered: true,
           isAnonymous: !!user.is_anonymous,
         };
@@ -37,6 +38,7 @@ export const profileService = (supabase: Supabase) => {
         id: userProfile.id,
         name: userProfile.name,
         displayId: userProfile.display_id,
+        avatarUrl: userProfile.avatar_url,
         isUnregistered:
           userProfile.name === null || userProfile.display_id === null,
         isAnonymous: !!user.is_anonymous,
@@ -46,9 +48,11 @@ export const profileService = (supabase: Supabase) => {
     updateUserProfile: async ({
       name,
       displayId,
+      avatarUrl,
     }: {
       name: string;
       displayId: string;
+      avatarUrl?: string;
     }): Promise<
       | {
           success: true;
@@ -65,7 +69,11 @@ export const profileService = (supabase: Supabase) => {
 
       const updatedUserProfileResponse = await supabase
         .from("profiles")
-        .update({ name, display_id: displayId })
+        .update({
+          name,
+          display_id: displayId,
+          avatar_url: avatarUrl,
+        })
         .eq("id", user.id)
         .select()
         .single();
@@ -79,6 +87,7 @@ export const profileService = (supabase: Supabase) => {
           id: updatedUserProfile.id,
           name: updatedUserProfile.name,
           displayId: updatedUserProfile.display_id,
+          avatarUrl: updatedUserProfile.avatar_url,
           isUnregistered:
             updatedUserProfile.name === null ||
             updatedUserProfile.display_id === null,
@@ -118,6 +127,7 @@ export const profileService = (supabase: Supabase) => {
         id: profile.id,
         name: profile.name,
         displayId: profile.display_id,
+        avatarUrl: profile.avatar_url,
         isFriend: friends.some((friend) => friend.friend_id === profile.id),
       }));
     },
@@ -135,7 +145,25 @@ export const profileService = (supabase: Supabase) => {
         id: profile.id,
         name: profile.name ?? name,
         displayId: profile.display_id,
+        avatarUrl: profile.avatar_url,
       };
+    },
+
+    uploadAvatar: async (file: File): Promise<string> => {
+      const userResponse = await supabase.auth.getUser();
+      if (userResponse.error) throw userResponse.error;
+      const user = userResponse.data.user;
+
+      const ext = file.name.split(".").pop();
+      const path = `${user.id}/avatar.${ext}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from("avatars")
+        .upload(path, file, { upsert: true, contentType: file.type });
+      if (uploadError) throw uploadError;
+
+      const { data } = supabase.storage.from("avatars").getPublicUrl(path);
+      return `${data.publicUrl}?t=${Date.now()}`;
     },
   };
 };

--- a/lib/services/features/profile.ts
+++ b/lib/services/features/profile.ts
@@ -154,8 +154,7 @@ export const profileService = (supabase: Supabase) => {
       if (userResponse.error) throw userResponse.error;
       const user = userResponse.data.user;
 
-      const ext = file.name.split(".").pop();
-      const path = `${user.id}/avatar.${ext}`;
+      const path = `${user.id}/avatar`;
 
       const { error: uploadError } = await supabase.storage
         .from("avatars")

--- a/lib/type.ts
+++ b/lib/type.ts
@@ -7,6 +7,7 @@ export type Profile = {
   id: string;
   name: string | null;
   displayId: string | null;
+  avatarUrl: string | null;
   isUnregistered?: boolean;
   isAnonymous?: boolean;
   isFriend?: boolean;

--- a/supabase/migrations/20260411000000_local.sql
+++ b/supabase/migrations/20260411000000_local.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."profiles"
+  ADD COLUMN "avatar_url" TEXT DEFAULT NULL;

--- a/supabase/migrations/20260412054823_local.sql
+++ b/supabase/migrations/20260412054823_local.sql
@@ -1,0 +1,32 @@
+
+  create policy "Public read access for avatars"
+  on "storage"."objects"
+  as permissive
+  for select
+  to public
+using ((bucket_id = 'avatars'::text));
+
+
+
+  create policy "Users can update own avatar"
+  on "storage"."objects"
+  as permissive
+  for update
+  to authenticated
+using (((bucket_id = 'avatars'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text)));
+
+
+
+  create policy "Users can upload own avatar"
+  on "storage"."objects"
+  as permissive
+  for insert
+  to authenticated
+with check (((bucket_id = 'avatars'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text)));
+
+
+CREATE TRIGGER protect_buckets_delete BEFORE DELETE ON storage.buckets FOR EACH STATEMENT EXECUTE FUNCTION storage.protect_delete();
+
+CREATE TRIGGER protect_objects_delete BEFORE DELETE ON storage.objects FOR EACH STATEMENT EXECUTE FUNCTION storage.protect_delete();
+
+


### PR DESCRIPTION
## 概要

プロフィール編集ページでアバター画像を設定できるようにした。Supabase Storage に画像を保存し、公開 URL を `profiles.avatar_url` に保存する。

## 変更内容

- `profiles` テーブルに `avatar_url` カラムを追加（マイグレーション）
- Supabase Storage に `avatars` バケットを作成（public、2MB 制限、jpg/png/webp）
- Storage の RLS ポリシーを設定（自分のフォルダのみ書き込み可）
- `AvatarInput` コンポーネントを新規作成
  - ファイル選択時に即座に Storage へアップロード
  - アップロード中は保存ボタンを `disabled` に（`onUploadingChange` コールバック経由）
  - アップロード済み URL を hidden input で保持し、Conform のスキーマと統合
- `profileUpdateSchema` に `avatarUrl` を追加してクライアント・サーバーで共有
- `updateUserProfile` サービスメソッドに `avatarUrl` 対応を追加
- `AppbarAvatar` でアバター画像を表示（未設定時はアイコンにフォールバック）
- `AVATAR_MAX_SIZE`・`AVATAR_ALLOWED_TYPES` 定数を `lib/config.ts` に追加