### PR TITLE
本番環境での画像アップロード失敗を修正（avatarsバケット作成マイグレーション追加）

### DIFF
--- a/supabase/migrations/20260412060517_create_avatars_bucket.sql
+++ b/supabase/migrations/20260412060517_create_avatars_bucket.sql
@@ -1,0 +1,3 @@
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars', 'avatars', true)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## 概要

本番環境で画像アップロードが失敗する問題を修正します。

## 原因

`avatars` ストレージバケットが開発環境では手動作成されていましたが、マイグレーションに含まれていなかったため本番環境にバケットが存在しない状態でした。ストレージポリシーは適用済みでもバケット自体がないためアップロードが失敗していました。

## 変更内容

- `20260412060517_create_avatars_bucket.sql` を追加
  - `avatars` バケットを public で作成
  - `ON CONFLICT DO NOTHING` により開発環境（バケット既存）では安全にスキップ
