### PR TITLE
match_playersのプレイヤー順序を固定

### DIFF
--- a/app/(main)/matches/[matchId]/_components/players-drawer/actions.ts
+++ b/app/(main)/matches/[matchId]/_components/players-drawer/actions.ts
@@ -32,7 +32,11 @@ export async function updateMatchPlayers(
 
   if (newPlayerIds.length > 0) {
     const { addMatchPlayers } = await serverServices();
-    await addMatchPlayers({ matchId, playerIds: newPlayerIds });
+    await addMatchPlayers({
+      matchId,
+      playerIds: newPlayerIds,
+      startOrder: existingPlayerIds.length,
+    });
     revalidatePath(`/matches/${matchId}`);
   }
 

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,10 @@
       }
     }
   },
-  "formatter": { "indentStyle": "space" },
+  "formatter": {
+    "indentStyle": "space",
+    "includes": ["**", "!lib/database.types.ts"]
+  },
   "assist": {
     "enabled": true,
     "actions": { "source": { "organizeImports": "on" } }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,3 +10,27 @@ pre-commit:
       run: "npm run test"
     "spell":
       run: "npm run spell"
+
+pre-push:
+  commands:
+    "supabase-diff":
+      run: |
+        npm run supabase:diff
+        if ! git diff --quiet -- supabase/migrations; then
+          echo ""
+          echo "ERROR: supabase:diff で新しいマイグレーションファイルが生成されました。"
+          echo "Supabase Studio の変更がマイグレーションに反映されていません。"
+          echo "生成されたファイルをコミットしてから再度 push してください。"
+          echo ""
+          exit 1
+        fi
+    "supabase-type":
+      run: |
+        npm run supabase:type
+        if ! git diff --quiet -- lib/database.types.ts; then
+          echo ""
+          echo "ERROR: supabase:type で型定義ファイルが更新されました。"
+          echo "lib/database.types.ts の変更をコミットしてから再度 push してください。"
+          echo ""
+          exit 1
+        fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,7 +27,6 @@ pre-push:
     "supabase-type":
       run: |
         npm run supabase:type
-        npx biome format --write lib/database.types.ts
         if ! git diff --quiet -- lib/database.types.ts; then
           echo ""
           echo "ERROR: supabase:type で型定義ファイルが更新されました。"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,6 +27,7 @@ pre-push:
     "supabase-type":
       run: |
         npm run supabase:type
+        npx biome format --write lib/database.types.ts
         if ! git diff --quiet -- lib/database.types.ts; then
           echo ""
           echo "ERROR: supabase:type で型定義ファイルが更新されました。"

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -12,6 +12,31 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.1";
   };
+  graphql_public: {
+    Tables: {
+      [_ in never]: never;
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       friends: {
@@ -123,16 +148,19 @@ export type Database = {
         Row: {
           chip_count: number | null;
           match_id: string;
+          order: number;
           player_id: string;
         };
         Insert: {
           chip_count?: number | null;
           match_id: string;
+          order?: number;
           player_id?: string;
         };
         Update: {
           chip_count?: number | null;
           match_id?: string;
+          order?: number;
           player_id?: string;
         };
         Relationships: [
@@ -409,6 +437,9 @@ export type CompositeTypes<
     : never;
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {},
   },

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4,341 +4,338 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.1";
-  };
+    PostgrestVersion: "14.1"
+  }
   graphql_public: {
     Tables: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
       graphql: {
         Args: {
-          extensions?: Json;
-          operationName?: string;
-          query?: string;
-          variables?: Json;
-        };
-        Returns: Json;
-      };
-    };
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       friends: {
         Row: {
-          created_at: string;
-          friend_id: string;
-          profile_id: string;
-        };
+          created_at: string
+          friend_id: string
+          profile_id: string
+        }
         Insert: {
-          created_at?: string;
-          friend_id: string;
-          profile_id?: string;
-        };
+          created_at?: string
+          friend_id: string
+          profile_id?: string
+        }
         Update: {
-          created_at?: string;
-          friend_id?: string;
-          profile_id?: string;
-        };
+          created_at?: string
+          friend_id?: string
+          profile_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "public_friends_friend_id_fkey";
-            columns: ["friend_id"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
+            foreignKeyName: "public_friends_friend_id_fkey"
+            columns: ["friend_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "public_friends_profile_id_fkey";
-            columns: ["profile_id"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
+            foreignKeyName: "public_friends_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       game_players: {
         Row: {
-          game_id: string;
-          player_id: string;
-          rank: number;
-          score: number;
-        };
+          game_id: string
+          player_id: string
+          rank: number
+          score: number
+        }
         Insert: {
-          game_id: string;
-          player_id?: string;
-          rank: number;
-          score: number;
-        };
+          game_id: string
+          player_id?: string
+          rank: number
+          score: number
+        }
         Update: {
-          game_id?: string;
-          player_id?: string;
-          rank?: number;
-          score?: number;
-        };
+          game_id?: string
+          player_id?: string
+          rank?: number
+          score?: number
+        }
         Relationships: [
           {
-            foreignKeyName: "scores_game_id_fkey";
-            columns: ["game_id"];
-            isOneToOne: false;
-            referencedRelation: "games";
-            referencedColumns: ["id"];
+            foreignKeyName: "scores_game_id_fkey"
+            columns: ["game_id"]
+            isOneToOne: false
+            referencedRelation: "games"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "scores_profile_id_fkey";
-            columns: ["player_id"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
+            foreignKeyName: "scores_profile_id_fkey"
+            columns: ["player_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       games: {
         Row: {
-          created_at: string;
-          created_by: string;
-          id: string;
-          match_id: string;
-        };
+          created_at: string
+          created_by: string
+          id: string
+          match_id: string
+        }
         Insert: {
-          created_at?: string;
-          created_by?: string;
-          id?: string;
-          match_id: string;
-        };
+          created_at?: string
+          created_by?: string
+          id?: string
+          match_id: string
+        }
         Update: {
-          created_at?: string;
-          created_by?: string;
-          id?: string;
-          match_id?: string;
-        };
+          created_at?: string
+          created_by?: string
+          id?: string
+          match_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "public_games_created_by_fkey";
-            columns: ["created_by"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
+            foreignKeyName: "public_games_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "public_games_match_id_fkey";
-            columns: ["match_id"];
-            isOneToOne: false;
-            referencedRelation: "matches";
-            referencedColumns: ["id"];
+            foreignKeyName: "public_games_match_id_fkey"
+            columns: ["match_id"]
+            isOneToOne: false
+            referencedRelation: "matches"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       match_players: {
         Row: {
-          chip_count: number | null;
-          match_id: string;
-          order: number;
-          player_id: string;
-        };
+          chip_count: number | null
+          match_id: string
+          order: number
+          player_id: string
+        }
         Insert: {
-          chip_count?: number | null;
-          match_id: string;
-          order?: number;
-          player_id?: string;
-        };
+          chip_count?: number | null
+          match_id: string
+          order?: number
+          player_id?: string
+        }
         Update: {
-          chip_count?: number | null;
-          match_id?: string;
-          order?: number;
-          player_id?: string;
-        };
+          chip_count?: number | null
+          match_id?: string
+          order?: number
+          player_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "matches_profiles_match_id_fkey";
-            columns: ["match_id"];
-            isOneToOne: false;
-            referencedRelation: "matches";
-            referencedColumns: ["id"];
+            foreignKeyName: "matches_profiles_match_id_fkey"
+            columns: ["match_id"]
+            isOneToOne: false
+            referencedRelation: "matches"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "matches_profiles_profile_id_fkey";
-            columns: ["player_id"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
+            foreignKeyName: "matches_profiles_profile_id_fkey"
+            columns: ["player_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       matches: {
         Row: {
-          created_at: string;
-          created_by: string;
-          id: string;
-        };
+          created_at: string
+          created_by: string
+          id: string
+        }
         Insert: {
-          created_at?: string;
-          created_by?: string;
-          id?: string;
-        };
+          created_at?: string
+          created_by?: string
+          id?: string
+        }
         Update: {
-          created_at?: string;
-          created_by?: string;
-          id?: string;
-        };
+          created_at?: string
+          created_by?: string
+          id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "matches_created_by_fkey";
-            columns: ["created_by"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
+            foreignKeyName: "matches_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       profiles: {
         Row: {
-          avatar_url: string | null;
-          display_id: string | null;
-          id: string;
-          name: string | null;
-        };
+          avatar_url: string | null
+          display_id: string | null
+          id: string
+          name: string | null
+        }
         Insert: {
-          avatar_url?: string | null;
-          display_id?: string | null;
-          id?: string;
-          name?: string | null;
-        };
+          avatar_url?: string | null
+          display_id?: string | null
+          id?: string
+          name?: string | null
+        }
         Update: {
-          avatar_url?: string | null;
-          display_id?: string | null;
-          id?: string;
-          name?: string | null;
-        };
-        Relationships: [];
-      };
+          avatar_url?: string | null
+          display_id?: string | null
+          id?: string
+          name?: string | null
+        }
+        Relationships: []
+      }
       rules: {
         Row: {
-          calc_method: string;
-          chip_rate: number;
-          crack_box_bonus: number;
-          created_at: string;
-          created_by: string;
-          default_calc_points: number;
-          default_points: number;
-          id: string;
-          incline: string;
-          match_id: string;
-          players_count: number;
-          rate: number;
-          updated_at: string;
-          updated_by: string;
-        };
+          calc_method: string
+          chip_rate: number
+          crack_box_bonus: number
+          created_at: string
+          created_by: string
+          default_calc_points: number
+          default_points: number
+          id: string
+          incline: string
+          match_id: string
+          players_count: number
+          rate: number
+          updated_at: string
+          updated_by: string
+        }
         Insert: {
-          calc_method: string;
-          chip_rate: number;
-          crack_box_bonus: number;
-          created_at?: string;
-          created_by?: string;
-          default_calc_points: number;
-          default_points: number;
-          id?: string;
-          incline: string;
-          match_id: string;
-          players_count: number;
-          rate: number;
-          updated_at?: string;
-          updated_by?: string;
-        };
+          calc_method: string
+          chip_rate: number
+          crack_box_bonus: number
+          created_at?: string
+          created_by?: string
+          default_calc_points: number
+          default_points: number
+          id?: string
+          incline: string
+          match_id: string
+          players_count: number
+          rate: number
+          updated_at?: string
+          updated_by?: string
+        }
         Update: {
-          calc_method?: string;
-          chip_rate?: number;
-          crack_box_bonus?: number;
-          created_at?: string;
-          created_by?: string;
-          default_calc_points?: number;
-          default_points?: number;
-          id?: string;
-          incline?: string;
-          match_id?: string;
-          players_count?: number;
-          rate?: number;
-          updated_at?: string;
-          updated_by?: string;
-        };
+          calc_method?: string
+          chip_rate?: number
+          crack_box_bonus?: number
+          created_at?: string
+          created_by?: string
+          default_calc_points?: number
+          default_points?: number
+          id?: string
+          incline?: string
+          match_id?: string
+          players_count?: number
+          rate?: number
+          updated_at?: string
+          updated_by?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "rules_created_by_fkey";
-            columns: ["created_by"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
+            foreignKeyName: "rules_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "rules_match_id_fkey";
-            columns: ["match_id"];
-            isOneToOne: false;
-            referencedRelation: "matches";
-            referencedColumns: ["id"];
+            foreignKeyName: "rules_match_id_fkey"
+            columns: ["match_id"]
+            isOneToOne: false
+            referencedRelation: "matches"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "rules_updated_by_fkey";
-            columns: ["updated_by"];
-            isOneToOne: false;
-            referencedRelation: "profiles";
-            referencedColumns: ["id"];
+            foreignKeyName: "rules_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<
-  keyof Database,
-  "public"
->];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R;
+      Row: infer R
     }
     ? R
     : never
@@ -346,95 +343,95 @@ export type Tables<
         DefaultSchema["Views"])
     ? (DefaultSchema["Tables"] &
         DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R;
+        Row: infer R
       }
       ? R
       : never
-    : never;
+    : never
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I;
+      Insert: infer I
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I;
+        Insert: infer I
       }
       ? I
       : never
-    : never;
+    : never
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U;
+      Update: infer U
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U;
+        Update: infer U
       }
       ? U
       : never
-    : never;
+    : never
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never;
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never;
+    : never
 
 export const Constants = {
   graphql_public: {
@@ -443,4 +440,4 @@ export const Constants = {
   public: {
     Enums: {},
   },
-} as const;
+} as const

--- a/lib/services/features/match.ts
+++ b/lib/services/features/match.ts
@@ -42,11 +42,12 @@ export const matchService = (supabase: Supabase) => {
 
       const matchPlayerRows =
         playerIds && playerIds.length > 0
-          ? playerIds.map((playerId) => ({
+          ? playerIds.map((playerId, index) => ({
               match_id: match.id,
               player_id: playerId,
+              order: index,
             }))
-          : [{ match_id: match.id }];
+          : [{ match_id: match.id, order: 0 }];
 
       const [createRuleResponse, createMatchPlayerResponse] = await Promise.all(
         [
@@ -79,6 +80,7 @@ export const matchService = (supabase: Supabase) => {
           "*, match_players(*, profiles!inner(*)), rules(*), games(*, game_players(*))",
         )
         .eq("id", matchId)
+        .order("order", { referencedTable: "match_players", ascending: true })
         .single();
       if (matchResult.error) throw matchResult.error;
       const match = matchResult.data;
@@ -100,7 +102,8 @@ export const matchService = (supabase: Supabase) => {
           { count: "exact" },
         )
         .range((page - 1) * size, page * size - 1)
-        .order("created_at", { ascending: false });
+        .order("created_at", { ascending: false })
+        .order("order", { referencedTable: "match_players", ascending: true });
 
       if (matchesResponse.error) throw matchesResponse.error;
       const matches = matchesResponse.data;
@@ -111,15 +114,18 @@ export const matchService = (supabase: Supabase) => {
     addMatchPlayers: async ({
       matchId,
       playerIds,
+      startOrder = 0,
     }: {
       matchId: string;
       playerIds: string[];
+      startOrder?: number;
     }): Promise<void> => {
       const addMatchPlayerResponses = await Promise.all(
-        playerIds.map((playerId) =>
+        playerIds.map((playerId, index) =>
           supabase.from("match_players").insert({
             match_id: matchId,
             player_id: playerId,
+            order: startOrder + index,
           }),
         ),
       );

--- a/lib/services/features/match.ts
+++ b/lib/services/features/match.ts
@@ -114,11 +114,11 @@ export const matchService = (supabase: Supabase) => {
     addMatchPlayers: async ({
       matchId,
       playerIds,
-      startOrder = 0,
+      startOrder,
     }: {
       matchId: string;
       playerIds: string[];
-      startOrder?: number;
+      startOrder: number;
     }): Promise<void> => {
       const addMatchPlayerResponses = await Promise.all(
         playerIds.map((playerId, index) =>

--- a/supabase/migrations/20260412120000_add_order_to_match_players.sql
+++ b/supabase/migrations/20260412120000_add_order_to_match_players.sql
@@ -1,0 +1,1 @@
+alter table "public"."match_players" add column "order" integer not null default 0;


### PR DESCRIPTION
## 概要

match tableでリロードするとプレイヤーの並び順が変わるバグを修正し、マッチ作成時に入力した順番が常に保持されるようにしました。またSupabase Studioで直接スキーマ変更した場合のドリフトをpush時に検知する仕組みも追加しました。

## 変更内容

- `match_players` テーブルに `order` カラムを追加するマイグレーション
- `createMatch` / `addMatchPlayers` でプレイヤー挿入時に入力順（0-indexed）を `order` に保存
- `getMatch` / `getMatches` クエリで `match_players` を `order` 昇順でソート
- `lib/database.types.ts` を再生成（`order` カラム追加を反映）
- `biome.json` に `lib/database.types.ts` をフォーマット対象外として設定
- `lefthook.yml` に `pre-push` フックを追加し、push時に `supabase:diff` と `supabase:type` を実行してスキーマ・型のドリフトを検知