### PR TITLE
Conform future API で空フォーム値を undefined に変換

### DIFF
--- a/app/(auth)/login/_components/login-form/schema.ts
+++ b/app/(auth)/login/_components/login-form/schema.ts
@@ -1,7 +1,10 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
-export const signInEmailSchema = z.object({
-  email: schema.email,
-  password: schema.password,
-});
+export const signInEmailSchema = coerceFormValue(
+  z.object({
+    email: schema.email,
+    password: schema.password,
+  }),
+);

--- a/app/(auth)/register/_components/register-form/schema.ts
+++ b/app/(auth)/register/_components/register-form/schema.ts
@@ -1,7 +1,10 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
-export const updateProfileSchema = z.object({
-  name: schema.name,
-  displayId: schema.displayId,
-});
+export const updateProfileSchema = coerceFormValue(
+  z.object({
+    name: schema.name,
+    displayId: schema.displayId,
+  }),
+);

--- a/app/(auth)/sign-up/_components/sign-up-form/schema.ts
+++ b/app/(auth)/sign-up/_components/sign-up-form/schema.ts
@@ -1,7 +1,10 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
-export const signUpSchema = z.object({
-  email: schema.email,
-  password: schema.password,
-});
+export const signUpSchema = coerceFormValue(
+  z.object({
+    email: schema.email,
+    password: schema.password,
+  }),
+);

--- a/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/schema.ts
+++ b/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/schema.ts
@@ -1,24 +1,27 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
-export const addChipSchema = z
-  .object({
-    playerChip: z.array(
-      z.object({
-        profileId: schema.profileId,
-        chipCount: z.string().transform(Number),
-      }),
-    ),
-  })
-  .superRefine(({ playerChip }, ctx) => {
-    const total = playerChip.reduce((acc, { chipCount }) => {
-      return acc + (chipCount ?? 0);
-    }, 0);
-    if (total !== 0) {
-      ctx.addIssue({
-        code: "custom",
-        message: `チップの合計が0枚なるように入力してください\n現在: ${total.toLocaleString()}枚`,
-        path: ["playerChip"],
-      });
-    }
-  });
+export const addChipSchema = coerceFormValue(
+  z
+    .object({
+      playerChip: z.array(
+        z.object({
+          profileId: schema.profileId,
+          chipCount: z.string("チップ枚数を入力してください").transform(Number),
+        }),
+      ),
+    })
+    .superRefine(({ playerChip }, ctx) => {
+      const total = playerChip.reduce((acc, { chipCount }) => {
+        return acc + (chipCount ?? 0);
+      }, 0);
+      if (total !== 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: `チップの合計が0枚なるように入力してください\n現在: ${total.toLocaleString()}枚`,
+          path: ["playerChip"],
+        });
+      }
+    }),
+);

--- a/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/schema.ts
+++ b/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/schema.ts
@@ -19,7 +19,7 @@ export const addChipSchema = coerceFormValue(
       if (total !== 0) {
         ctx.addIssue({
           code: "custom",
-          message: `チップの合計が0枚なるように入力してください\n現在: ${total.toLocaleString()}枚`,
+          message: `チップの合計が0枚になるように入力してください\n現在: ${total.toLocaleString()}枚`,
           path: ["playerChip"],
         });
       }

--- a/app/(main)/matches/[matchId]/_components/create-game-drawer/schema.ts
+++ b/app/(main)/matches/[matchId]/_components/create-game-drawer/schema.ts
@@ -1,3 +1,4 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
@@ -8,52 +9,54 @@ export const createCreateGameSchema = ({
   playersCount: number;
   defaultPoints: number;
 }) =>
-  z
-    .object({
-      players: z.array(
-        z.object({
-          id: schema.profileId,
-          points: schema.points.optional(),
-          name: schema.name,
-        }),
-      ),
-      crackBoxPlayerId: schema.profileId.optional(),
-    })
-    .superRefine(({ players }, ctx) => {
-      const filledCount = players.filter(
-        ({ points }) => points !== undefined,
-      ).length;
-      if (filledCount !== playersCount) {
-        ctx.addIssue({
-          code: "custom",
-          message: `${playersCount}人分の点数を入力してください`,
-          path: ["players"],
-        });
-      }
-    })
-    .superRefine(({ players }, ctx) => {
-      const total = players.reduce((acc, { points }) => {
-        return acc + (points ?? 0);
-      }, 0);
-      const expected = playersCount * defaultPoints;
-      if (total !== expected) {
-        const diff = expected - total;
-        ctx.addIssue({
-          code: "custom",
-          message: `点数の合計が${expected.toLocaleString()}点になるように入力してください\n${diff.toLocaleString()}点${diff > 0 ? "足りません" : "多いです"}`,
-          path: ["players"],
-        });
-      }
-    })
-    .superRefine(({ players, crackBoxPlayerId }, ctx) => {
-      const underZeroPointsPlayerExists = players.some(
-        ({ points }) => typeof points === "number" && points < 0,
-      );
-      if (!underZeroPointsPlayerExists && crackBoxPlayerId !== undefined) {
-        ctx.addIssue({
-          code: "custom",
-          message: "0点を下回るプレイヤーがいません",
-          path: ["crackBoxPlayerId"],
-        });
-      }
-    });
+  coerceFormValue(
+    z
+      .object({
+        players: z.array(
+          z.object({
+            id: schema.profileId,
+            points: schema.points.optional(),
+            name: schema.name,
+          }),
+        ),
+        crackBoxPlayerId: schema.profileId.optional(),
+      })
+      .superRefine(({ players }, ctx) => {
+        const filledCount = players.filter(
+          ({ points }) => points !== undefined,
+        ).length;
+        if (filledCount !== playersCount) {
+          ctx.addIssue({
+            code: "custom",
+            message: `${playersCount}人分の点数を入力してください`,
+            path: ["players"],
+          });
+        }
+      })
+      .superRefine(({ players }, ctx) => {
+        const total = players.reduce((acc, { points }) => {
+          return acc + (points ?? 0);
+        }, 0);
+        const expected = playersCount * defaultPoints;
+        if (total !== expected) {
+          const diff = expected - total;
+          ctx.addIssue({
+            code: "custom",
+            message: `点数の合計が${expected.toLocaleString()}点になるように入力してください\n${diff.toLocaleString()}点${diff > 0 ? "足りません" : "多いです"}`,
+            path: ["players"],
+          });
+        }
+      })
+      .superRefine(({ players, crackBoxPlayerId }, ctx) => {
+        const underZeroPointsPlayerExists = players.some(
+          ({ points }) => typeof points === "number" && points < 0,
+        );
+        if (!underZeroPointsPlayerExists && crackBoxPlayerId !== undefined) {
+          ctx.addIssue({
+            code: "custom",
+            message: "0点を下回るプレイヤーがいません",
+            path: ["crackBoxPlayerId"],
+          });
+        }
+      }),
+  );

--- a/app/(main)/matches/[matchId]/_components/players-drawer/schema.ts
+++ b/app/(main)/matches/[matchId]/_components/players-drawer/schema.ts
@@ -1,5 +1,10 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 
-export const updatePlayersSchema = z.object({
-  playerIds: z.array(z.string()).min(1, "プレイヤーを1人以上選択してください"),
-});
+export const updatePlayersSchema = coerceFormValue(
+  z.object({
+    playerIds: z
+      .array(z.string())
+      .min(1, "プレイヤーを1人以上選択してください"),
+  }),
+);

--- a/app/(main)/matches/_components/create-match-drawer/player-form/schema.ts
+++ b/app/(main)/matches/_components/create-match-drawer/player-form/schema.ts
@@ -1,8 +1,11 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 
 export const createPlayerStepSchema = (playersCount: number) =>
-  z.object({
-    playerIds: z
-      .array(z.string())
-      .min(playersCount, `プレイヤーを${playersCount}人以上選択してください`),
-  });
+  coerceFormValue(
+    z.object({
+      playerIds: z
+        .array(z.string())
+        .min(playersCount, `プレイヤーを${playersCount}人以上選択してください`),
+    }),
+  );

--- a/app/(main)/matches/_components/create-match-drawer/rule-form/schema.ts
+++ b/app/(main)/matches/_components/create-match-drawer/rule-form/schema.ts
@@ -1,3 +1,4 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
@@ -22,10 +23,12 @@ const threePlayerFields = {
   ...commonFields,
 };
 
-export const ruleSchema = z.discriminatedUnion("playersCount", [
-  z.object(fourPlayerFields),
-  z.object(threePlayerFields),
-]);
+export const ruleSchema = coerceFormValue(
+  z.discriminatedUnion("playersCount", [
+    z.object(fourPlayerFields),
+    z.object(threePlayerFields),
+  ]),
+);
 
 export type RuleInput = z.input<typeof ruleSchema>;
 export type RuleOutput = z.output<typeof ruleSchema>;

--- a/app/(main)/matches/_components/player-selector/create-player-modal/schema.ts
+++ b/app/(main)/matches/_components/player-selector/create-player-modal/schema.ts
@@ -1,6 +1,9 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
-export const createPlayerSchema = z.object({
-  name: schema.name,
-});
+export const createPlayerSchema = coerceFormValue(
+  z.object({
+    name: schema.name,
+  }),
+);

--- a/app/(main)/profile/_components/profile-form/schema.ts
+++ b/app/(main)/profile/_components/profile-form/schema.ts
@@ -1,6 +1,9 @@
+import { coerceFormValue } from "@conform-to/zod/v4/future";
 import { z } from "zod";
 import { schema } from "@/lib/utils/schema";
 
-export const profileUpdateSchema = z.object({
-  name: schema.name,
-});
+export const profileUpdateSchema = coerceFormValue(
+  z.object({
+    name: schema.name,
+  }),
+);


### PR DESCRIPTION
## 概要

`@conform-to/react/future` の `parseSubmission` はデフォルトで空文字を `undefined` に変換しないため、Zod スキーマに生の空文字が渡り、`z.string().optional()` などが意図通りに動かないバグが発生していました（`crackBoxPlayerId` が未選択時に `''` のまま扱われるなど）。

Conform 公式は future API と組み合わせる場合 `@conform-to/zod/v4/future` の `coerceFormValue` で空値除去・型 coercion を行うよう案内しているため、全てのフォームスキーマをそれでラップし直しました。

## 変更内容

- 全 10 フォームスキーマを `coerceFormValue` でラップ
  - auth: login / register / sign-up
  - profile: profile-form
  - matches: create-match-drawer (rule-form / player-form), create-game-drawer, chip-drawer, players-drawer, player-selector (create-player-modal)
- `create-game-drawer` の `crackBoxPlayerId` 判定を `!!crackBoxPlayerId` のワークアラウンドから `!== undefined` に復帰
- `chip-form` の `chipCount` に必須エラーメッセージ `"チップ枚数を入力してください"` を追加（coerce で空文字 → undefined になり既定のメッセージでは不親切だったため）

## 挙動変化（副次効果）

coerce が効くようになったことで、今まで空文字が silently に通っていた required フィールドが適切にバリデーションされるようになります:

- 名前・ユーザーID 等 `schema.name` / `schema.displayId` を使う箇所が空文字で弾かれる
- カスタムチップレート・カスタムウマが空欄の場合に適切なエラーが出る
- `crackBoxPlayerId` が "なし"（空文字）選択時に `undefined` 扱いになる

## 検証

- \`npm run type\` passed
- \`npm run lint\` passed
- \`npm run test\` passed (7/7)

Made with [Cursor](https://cursor.com)