### PR TITLE
E2Eテスト拡充（フォームバリデーション・各種フロー）

### DIFF
--- a/app/(auth)/login/_components/login-form/index.tsx
+++ b/app/(auth)/login/_components/login-form/index.tsx
@@ -33,7 +33,8 @@ export function LoginForm({ className }: { className?: string }) {
     >
       <div className="space-y-4">
         <TextField
-          type="email"
+          type="text"
+          inputMode="email"
           name={fields.email.name}
           autoComplete="username"
         >

--- a/app/(auth)/sign-up/_components/sign-up-form/index.tsx
+++ b/app/(auth)/sign-up/_components/sign-up-form/index.tsx
@@ -35,7 +35,8 @@ export function SignUpForm({ className }: { className?: string }) {
       <div>
         <div className="space-y-4">
           <TextField
-            type="email"
+            type="text"
+            inputMode="email"
             name={fields.email.name}
             autoComplete="username"
           >

--- a/app/(main)/_components/appbar/appbar-avatar/index.tsx
+++ b/app/(main)/_components/appbar/appbar-avatar/index.tsx
@@ -18,7 +18,10 @@ export async function AppbarAvatar() {
 
   return (
     <Dropdown>
-      <Dropdown.Trigger className="rounded-full">
+      <Dropdown.Trigger
+        className="rounded-full"
+        aria-label="プロフィールメニュー"
+      >
         <UserAvatar
           avatarUrl={profile.avatarUrl}
           name={profile.name}

--- a/app/(main)/friends/_components/add-button/index.tsx
+++ b/app/(main)/friends/_components/add-button/index.tsx
@@ -9,6 +9,7 @@ export function AddButton() {
     <NextLink
       className={buttonVariants({ isIconOnly: true, variant: "ghost" })}
       href="/friends/add"
+      aria-label="フレンド追加"
     >
       <UserPlus />
     </NextLink>

--- a/app/(main)/friends/_components/friend-menu/index.tsx
+++ b/app/(main)/friends/_components/friend-menu/index.tsx
@@ -16,7 +16,12 @@ export function FriendMenu({ profileId }: { profileId: string }) {
 
   return (
     <Dropdown>
-      <Button size="sm" variant="ghost" isIconOnly>
+      <Button
+        size="sm"
+        variant="ghost"
+        isIconOnly
+        aria-label="フレンドメニュー"
+      >
         <EllipsisVertical />
       </Button>
       <Dropdown.Popover>

--- a/app/(main)/friends/add/_components/back-button.tsx
+++ b/app/(main)/friends/add/_components/back-button.tsx
@@ -9,6 +9,7 @@ export function BackButton() {
     <NextLink
       className={buttonVariants({ isIconOnly: true, variant: "ghost" })}
       href="/friends"
+      aria-label="戻る"
     >
       <ChevronLeft />
     </NextLink>

--- a/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
@@ -114,7 +114,7 @@ export function ChipForm({
                           </Button>
                         </InputGroup.Prefix>
                       )}
-                      <InputGroup.Input className="min-w-0 text-right" />
+                      <InputGroup.Input className="min-w-1 text-right" />
                       <InputGroup.Suffix>枚</InputGroup.Suffix>
                     </InputGroup>
                   </div>

--- a/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  parseSubmission,
-  useForm,
-  useFormData,
-} from "@conform-to/react/future";
+import { getFieldValue, useForm, useFormData } from "@conform-to/react/future";
 import {
   Drawer,
   FieldError,
@@ -12,7 +8,7 @@ import {
   Label,
   TextField,
 } from "@heroui/react";
-import { useActionState, useRef } from "react";
+import { useActionState } from "react";
 import { Button } from "@/components/button";
 import { Form } from "@/components/form";
 import type { Match } from "@/lib/type";
@@ -27,10 +23,7 @@ export function ChipForm({
   match: Match;
   onOpenChange: (isOpen: boolean) => void;
 }) {
-  const formRef = useRef<HTMLFormElement>(null);
   const { players, rule } = match;
-
-  console.log(players);
 
   const [lastResult, formAction, isPending] = useActionState(
     withCallbacks(addChip, {
@@ -51,20 +44,16 @@ export function ChipForm({
     },
   });
 
-  const payload = useFormData(
-    formRef,
-    (fd) => (fd ? parseSubmission(fd).payload : null),
-    { fallback: null },
-  );
-  const playerChipList = Array.isArray(payload?.playerChip)
-    ? payload.playerChip
-    : payload?.playerChip && typeof payload.playerChip === "object"
-      ? Object.keys(payload.playerChip)
-          .sort((a, b) => Number(a) - Number(b))
-          .map((i) => (payload.playerChip as Record<string, unknown>)[i])
-      : [];
-  const chipCounts = playerChipList.map((item: unknown) =>
-    String((item as Record<string, unknown>)?.chipCount ?? ""),
+  const playerChips =
+    useFormData(form.id, (formData) =>
+      getFieldValue(formData, fields.playerChip.name, {
+        type: "object",
+        array: true,
+      }),
+    ) ?? [];
+
+  const chipCounts = playerChips.map((p) =>
+    String((p as { chipCount?: string })?.chipCount ?? ""),
   );
   const totalChipCount = chipCounts.reduce((sum, v) => sum + Number(v) || 0, 0);
   const filledCount = chipCounts.filter((v) => v !== "").length;
@@ -74,7 +63,6 @@ export function ChipForm({
 
   return (
     <Form
-      ref={formRef}
       className="contents"
       validationErrors={form.fieldErrors}
       {...form.props}

--- a/app/(main)/matches/[matchId]/_components/create-game-drawer/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/create-game-drawer/index.tsx
@@ -166,7 +166,7 @@ export function CreateGameDrawer({
                                   </Button>
                                 </InputGroup.Prefix>
                               )}
-                              <InputGroup.Input className="min-w-0 text-right" />
+                              <InputGroup.Input className="min-w-1 text-right" />
                               <InputGroup.Suffix className="pl-1">
                                 <span
                                   className={cn("mt-0.5 mr-1 text-xs", {

--- a/app/(main)/matches/[matchId]/_components/match-header/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/match-header/index.tsx
@@ -27,6 +27,7 @@ export function MatchHeader({
           <NextLink
             className={buttonVariants({ isIconOnly: true, variant: "ghost" })}
             href="/matches"
+            aria-label="戻る"
           >
             <ChevronLeft />
           </NextLink>
@@ -37,6 +38,7 @@ export function MatchHeader({
           <Button
             isIconOnly
             variant="ghost"
+            aria-label="ルールを確認"
             onClick={ruleModal.open}
             className={buttonVariants({
               isIconOnly: true,
@@ -49,6 +51,7 @@ export function MatchHeader({
           <Button
             isIconOnly
             variant="ghost"
+            aria-label="プレイヤーを追加"
             onClick={playersModal.open}
             className={buttonVariants({
               isIconOnly: true,

--- a/cspell.json
+++ b/cspell.json
@@ -22,6 +22,7 @@
     "pressable",
     "reauthentication",
     "rocknroll",
+    "spinbutton",
     "supabase",
     "testuser",
     "turbopack",

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { fillEmail } from "./helpers";
 
 test.describe("ログイン", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
@@ -6,9 +7,7 @@ test.describe("ログイン", () => {
   test("正しい認証情報でログインできる", async ({ page }) => {
     await page.goto("/login");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill("test@example.com");
+    await fillEmail(page, "test@example.com");
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
@@ -18,9 +17,7 @@ test.describe("ログイン", () => {
   test("誤ったパスワードではログインできない", async ({ page }) => {
     await page.goto("/login");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill("test@example.com");
+    await fillEmail(page, "test@example.com");
     await page
       .getByRole("textbox", { name: "パスワード" })
       .fill("wrongpassword");
@@ -35,9 +32,7 @@ test.describe("ログイン", () => {
   test("未登録のメールアドレスではログインできない", async ({ page }) => {
     await page.goto("/login");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill("nobody@example.com");
+    await fillEmail(page, "nobody@example.com");
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
@@ -62,9 +57,7 @@ test.describe("ログイン", () => {
   test("メールアドレス形式が不正ならバリデーションエラー", async ({ page }) => {
     await page.goto("/login");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill("not-an-email");
+    await fillEmail(page, "not-an-email");
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
@@ -77,9 +70,7 @@ test.describe("ログイン", () => {
   test("パスワード未入力ではバリデーションエラー", async ({ page }) => {
     await page.goto("/login");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill("test@example.com");
+    await fillEmail(page, "test@example.com");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
     await expect(page.getByText("パスワードを入力してください")).toBeVisible();
@@ -89,9 +80,7 @@ test.describe("ログイン", () => {
   test("パスワードが短いとバリデーションエラー", async ({ page }) => {
     await page.goto("/login");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill("test@example.com");
+    await fillEmail(page, "test@example.com");
     await page.getByRole("textbox", { name: "パスワード" }).fill("12345");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -15,7 +15,7 @@ test.describe("ログイン", () => {
     await expect(page).toHaveURL("/matches");
   });
 
-  test("誤った認証情報ではログインできない", async ({ page }) => {
+  test("誤ったパスワードではログインできない", async ({ page }) => {
     await page.goto("/login");
 
     await page
@@ -32,28 +32,88 @@ test.describe("ログイン", () => {
     await expect(page).toHaveURL("/login");
   });
 
-  test("未認証ユーザーはログインページにリダイレクトされる", async ({
-    page,
-  }) => {
-    await page.goto("/matches");
+  test("未登録のメールアドレスではログインできない", async ({ page }) => {
+    await page.goto("/login");
 
-    await expect(page).toHaveURL(/\/login/);
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill("nobody@example.com");
+    await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+    await page.getByRole("button", { name: "ログイン", exact: true }).click();
+
+    await expect(
+      page.getByText("メールアドレスまたはパスワードが間違っています"),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/login");
   });
-});
 
-test.describe("ログアウト", () => {
-  test("ログアウトするとログインページにリダイレクトされ、再アクセスもできない", async ({
+  test("メールアドレス未入力ではバリデーションエラー", async ({ page }) => {
+    await page.goto("/login");
+
+    await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+    await page.getByRole("button", { name: "ログイン", exact: true }).click();
+
+    await expect(
+      page.getByText("メールアドレスを入力してください"),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/login");
+  });
+
+  test("メールアドレス形式が不正ならバリデーションエラー", async ({ page }) => {
+    await page.goto("/login");
+
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill("not-an-email");
+    await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+    await page.getByRole("button", { name: "ログイン", exact: true }).click();
+
+    await expect(
+      page.getByText("メールアドレスを正しい形式で入力してください"),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/login");
+  });
+
+  test("パスワード未入力ではバリデーションエラー", async ({ page }) => {
+    await page.goto("/login");
+
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill("test@example.com");
+    await page.getByRole("button", { name: "ログイン", exact: true }).click();
+
+    await expect(page.getByText("パスワードを入力してください")).toBeVisible();
+    await expect(page).toHaveURL("/login");
+  });
+
+  test("パスワードが短いとバリデーションエラー", async ({ page }) => {
+    await page.goto("/login");
+
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill("test@example.com");
+    await page.getByRole("textbox", { name: "パスワード" }).fill("12345");
+    await page.getByRole("button", { name: "ログイン", exact: true }).click();
+
+    await expect(
+      page.getByText("パスワードは6文字以上で入力してください"),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/login");
+  });
+
+  test("未認証ユーザーは各保護ページにアクセスするとログインページにリダイレクトされる", async ({
     page,
   }) => {
-    await page.goto("/matches");
-    await expect(page).toHaveURL("/matches");
+    for (const path of ["/matches", "/friends", "/profile"]) {
+      await page.goto(path);
+      await expect(page).toHaveURL(/\/login/);
+    }
+  });
 
-    await page.getByRole("button", { name: "プロフィールメニュー" }).click();
-    await page.getByRole("menuitem", { name: "ログアウト" }).click();
-
-    await expect(page).toHaveURL(/\/login/);
-
-    await page.goto("/matches");
-    await expect(page).toHaveURL(/\/login/);
+  test("ログインページに新規登録ページへのリンクが存在する", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("link", { name: "新規登録" })).toBeVisible();
   });
 });

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { fillEmail } from "./helpers";
+import { fillInput } from "./helpers";
 
 test.describe("ログイン", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
@@ -7,7 +7,10 @@ test.describe("ログイン", () => {
   test("正しい認証情報でログインできる", async ({ page }) => {
     await page.goto("/login");
 
-    await fillEmail(page, "test@example.com");
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      "test@example.com",
+    );
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
@@ -17,7 +20,10 @@ test.describe("ログイン", () => {
   test("誤ったパスワードではログインできない", async ({ page }) => {
     await page.goto("/login");
 
-    await fillEmail(page, "test@example.com");
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      "test@example.com",
+    );
     await page
       .getByRole("textbox", { name: "パスワード" })
       .fill("wrongpassword");
@@ -32,7 +38,10 @@ test.describe("ログイン", () => {
   test("未登録のメールアドレスではログインできない", async ({ page }) => {
     await page.goto("/login");
 
-    await fillEmail(page, "nobody@example.com");
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      "nobody@example.com",
+    );
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
@@ -57,7 +66,10 @@ test.describe("ログイン", () => {
   test("メールアドレス形式が不正ならバリデーションエラー", async ({ page }) => {
     await page.goto("/login");
 
-    await fillEmail(page, "not-an-email");
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      "not-an-email",
+    );
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
@@ -70,7 +82,10 @@ test.describe("ログイン", () => {
   test("パスワード未入力ではバリデーションエラー", async ({ page }) => {
     await page.goto("/login");
 
-    await fillEmail(page, "test@example.com");
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      "test@example.com",
+    );
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
     await expect(page.getByText("パスワードを入力してください")).toBeVisible();
@@ -80,7 +95,10 @@ test.describe("ログイン", () => {
   test("パスワードが短いとバリデーションエラー", async ({ page }) => {
     await page.goto("/login");
 
-    await fillEmail(page, "test@example.com");
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      "test@example.com",
+    );
     await page.getByRole("textbox", { name: "パスワード" }).fill("12345");
     await page.getByRole("button", { name: "ログイン", exact: true }).click();
 

--- a/e2e/create-match.spec.ts
+++ b/e2e/create-match.spec.ts
@@ -1,0 +1,294 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { TEST_USERS } from "./helpers";
+
+async function openCreateMatchDrawer(page: Page) {
+  await page.goto("/matches");
+  await page.getByRole("button", { name: "ゲームを始める" }).click();
+  await expect(page.getByRole("dialog", { name: "ゲーム作成" })).toBeVisible();
+}
+
+/**
+ * HeroUIのRadioは視覚的に隠されたinput[type=radio]を使うため、
+ * 通常のクリックは親要素のlabelに遮られる。
+ * inputへのdispatchEventでチェックしたあと、変更イベントも明示的に発火させる。
+ */
+async function clickRadio(scope: Locator, name: string | RegExp, nth = 0) {
+  const radio = scope.getByRole("radio", { name }).nth(nth);
+  await radio.dispatchEvent("click");
+}
+
+test.describe("ゲーム作成 - ルール設定", () => {
+  test("デフォルトは四麻", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    // プレイ人数が "四麻" のラジオがチェックされている
+    await expect(dialog.getByRole("radio", { name: "四麻" })).toBeChecked();
+  });
+
+  test("三麻に切り替えるとウマ選択肢が3人用になる", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await clickRadio(dialog, "三麻");
+    await expect(dialog.getByRole("radio", { name: "三麻" })).toBeChecked();
+
+    // 3人用ウマプリセット: ウマ10, ウマ20, ウマ30
+    await expect(dialog.getByRole("radio", { name: "ウマ10" })).toBeVisible();
+    await expect(dialog.getByRole("radio", { name: "ウマ20" })).toBeVisible();
+    await expect(dialog.getByRole("radio", { name: "ウマ30" })).toBeVisible();
+  });
+
+  test("四麻時のウマプリセットが表示される", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await expect(dialog.getByRole("radio", { name: "ゴットー" })).toBeVisible();
+    await expect(dialog.getByRole("radio", { name: "ワンツー" })).toBeVisible();
+    await expect(
+      dialog.getByRole("radio", { name: "ワンスリー" }),
+    ).toBeVisible();
+  });
+
+  test("レート選択肢が表示される", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    for (const label of [
+      "テンイチ",
+      "テンサン",
+      "テンゴ",
+      "テンピン",
+      "リャンピン",
+    ]) {
+      await expect(dialog.getByRole("radio", { name: label })).toBeVisible();
+    }
+    // "なし" はレート以外にもウマ/チップで3箇所あるので件数のみ確認
+    await expect(dialog.getByRole("radio", { name: "なし" })).toHaveCount(3);
+  });
+
+  test("ウマ カスタム: 合計が0にならないとエラー", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await clickRadio(dialog, "カスタム", 0);
+
+    await dialog.getByRole("spinbutton", { name: "1着" }).fill("10");
+    await dialog.getByRole("spinbutton", { name: "2着" }).fill("5");
+    await dialog.getByRole("spinbutton", { name: "3着" }).fill("-5");
+    await dialog.getByRole("spinbutton", { name: "4着" }).fill("-5");
+
+    await dialog.getByRole("button", { name: "プレイヤー選択へ" }).click();
+    await expect(
+      dialog.getByText("ウマの合計が0になるように入力してください"),
+    ).toBeVisible();
+  });
+
+  test("ウマ カスタム: 4着が空欄ならエラー", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await clickRadio(dialog, "カスタム", 0);
+
+    await dialog.getByRole("spinbutton", { name: "1着" }).fill("10");
+    await dialog.getByRole("spinbutton", { name: "2着" }).fill("5");
+    await dialog.getByRole("spinbutton", { name: "3着" }).fill("-5");
+
+    await dialog.getByRole("button", { name: "プレイヤー選択へ" }).click();
+    await expect(dialog.getByText("ウマを入力してください")).toBeVisible();
+  });
+
+  test("チップ カスタム: 負数だとエラー", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    // "チップ" のラジオグループ内でカスタムを選択
+    // オプションカードのカスタムは2箇所（ウマとチップ）あるので2番目
+    await clickRadio(dialog, "カスタム", 1);
+
+    await dialog.getByRole("spinbutton", { name: "カスタム" }).fill("-100");
+
+    await dialog.getByRole("button", { name: "プレイヤー選択へ" }).click();
+    await expect(
+      dialog.getByText("チップレートは0以上で入力してください"),
+    ).toBeVisible();
+  });
+
+  test("詳細設定を展開すると飛び賞・持ち点・オカ・計算が表示される", async ({
+    page,
+  }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await dialog.getByRole("button", { name: "詳細設定" }).click();
+
+    await expect(
+      dialog.getByRole("spinbutton", { name: "飛び賞" }),
+    ).toHaveValue("10000");
+    await expect(
+      dialog.getByRole("spinbutton", { name: "持ち点" }),
+    ).toHaveValue("25000");
+    await expect(dialog.getByRole("spinbutton", { name: "オカ" })).toHaveValue(
+      "30000",
+    );
+  });
+
+  test("三麻に切り替えると持ち点のデフォルトが35000になる", async ({
+    page,
+  }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await clickRadio(dialog, "三麻");
+    await dialog.getByRole("button", { name: "詳細設定" }).click();
+
+    await expect(
+      dialog.getByRole("spinbutton", { name: "持ち点" }),
+    ).toHaveValue("35000");
+    await expect(dialog.getByRole("spinbutton", { name: "オカ" })).toHaveValue(
+      "40000",
+    );
+  });
+});
+
+test.describe("ゲーム作成 - プレイヤー選択", () => {
+  async function goToPlayerStep(page: Page) {
+    await openCreateMatchDrawer(page);
+    await page.getByRole("button", { name: "プレイヤー選択へ" }).click();
+    // ステップ2に到達
+    await expect(
+      page.getByRole("button", { name: "ゲーム開始" }),
+    ).toBeVisible();
+  }
+
+  test("自分は最初から選択済みで削除できない", async ({ page }) => {
+    await goToPlayerStep(page);
+
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+    await expect(dialog.getByText("選択中")).toBeVisible();
+    await expect(dialog.getByText(TEST_USERS.me.name)).toBeVisible();
+  });
+
+  test("プレイヤーが足りないとエラー表示", async ({ page }) => {
+    await goToPlayerStep(page);
+
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+    await dialog.getByRole("button", { name: "ゲーム開始" }).click();
+
+    await expect(
+      dialog.getByText("プレイヤーを4人以上選択してください"),
+    ).toBeVisible();
+  });
+
+  test("ユーザー検索結果から追加・削除できる", async ({ page }) => {
+    await goToPlayerStep(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await dialog.getByRole("searchbox").fill(TEST_USERS.alice.displayId);
+
+    const option = dialog
+      .getByRole("option", { name: new RegExp(TEST_USERS.alice.name) })
+      .first();
+    await expect(option).toBeVisible();
+
+    await option.click();
+
+    // クリック後、「選択中」パラグラフが表示されAliceが含まれるようになる
+    await expect(dialog.getByText("選択中")).toBeVisible();
+    // option + 選択中チップの2箇所でAliceの名前が登場
+    await expect(dialog.getByText(TEST_USERS.alice.name)).toHaveCount(2);
+  });
+
+  test("戻るボタンで1ステップ目に戻れる", async ({ page }) => {
+    await goToPlayerStep(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await dialog.getByRole("button", { name: "戻る" }).click();
+    await expect(
+      dialog.getByRole("button", { name: "プレイヤー選択へ" }),
+    ).toBeVisible();
+  });
+
+  test("新規プレイヤー作成モーダル: 空だとエラー", async ({ page }) => {
+    await goToPlayerStep(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await dialog.getByRole("option", { name: "新規プレイヤー作成" }).click();
+
+    const modal = page.getByRole("dialog", { name: "新規プレイヤー作成" });
+    await expect(modal).toBeVisible();
+
+    await modal.getByRole("button", { name: "決定" }).click();
+    await expect(modal.getByText("名前を入力してください")).toBeVisible();
+  });
+
+  test("新規プレイヤー作成: 名前が長すぎるとエラー", async ({ page }) => {
+    await goToPlayerStep(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await dialog.getByRole("option", { name: "新規プレイヤー作成" }).click();
+    const modal = page.getByRole("dialog", { name: "新規プレイヤー作成" });
+
+    // NOTE: maxLength属性が設定されているので入力自体が12文字で切られる
+    // バリデーションを発火させるため、直接DOMに13文字セット
+    const input = modal.getByRole("textbox");
+    await input.fill("あいうえおかきくけこさしす");
+
+    // maxLength属性のため12文字までしか入力されない
+    await expect(input).toHaveValue("あいうえおかきくけこさし");
+  });
+
+  test("新規プレイヤー作成: 成功すると選択中に追加される", async ({ page }) => {
+    await goToPlayerStep(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await dialog.getByRole("option", { name: "新規プレイヤー作成" }).click();
+    const modal = page.getByRole("dialog", { name: "新規プレイヤー作成" });
+
+    const playerName = `仮名${Date.now()}`.slice(0, 12);
+    await modal.getByRole("textbox").fill(playerName);
+    await modal.getByRole("button", { name: "決定" }).click();
+
+    await expect(modal).not.toBeVisible();
+    await expect(dialog.getByText(playerName)).toBeVisible();
+  });
+});
+
+test.describe("ゲーム作成 - 完了フロー", () => {
+  test("四麻・プレイヤー4人を指定してゲームを開始できる", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    await page.getByRole("button", { name: "プレイヤー選択へ" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    // seedでalice/bob/carolはフレンドに登録されているため、検索不要でデフォルトリストから選択できる
+    for (const user of [TEST_USERS.alice, TEST_USERS.bob, TEST_USERS.carol]) {
+      await dialog
+        .getByRole("option", { name: new RegExp(user.name) })
+        .first()
+        .click();
+    }
+
+    await dialog.getByRole("button", { name: "ゲーム開始" }).click();
+
+    await expect(page).toHaveURL(/\/matches\/[a-f0-9-]+/);
+  });
+
+  test("三麻・プレイヤー3人でゲームを開始できる", async ({ page }) => {
+    await openCreateMatchDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+
+    await clickRadio(dialog, "三麻");
+    await dialog.getByRole("button", { name: "プレイヤー選択へ" }).click();
+
+    for (const user of [TEST_USERS.alice, TEST_USERS.bob]) {
+      await dialog
+        .getByRole("option", { name: new RegExp(user.name) })
+        .first()
+        .click();
+    }
+
+    await dialog.getByRole("button", { name: "ゲーム開始" }).click();
+    await expect(page).toHaveURL(/\/matches\/[a-f0-9-]+/);
+  });
+});

--- a/e2e/create-match.spec.ts
+++ b/e2e/create-match.spec.ts
@@ -1,20 +1,10 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { TEST_USERS } from "./helpers";
 
 async function openCreateMatchDrawer(page: Page) {
   await page.goto("/matches");
   await page.getByRole("button", { name: "ゲームを始める" }).click();
   await expect(page.getByRole("dialog", { name: "ゲーム作成" })).toBeVisible();
-}
-
-/**
- * HeroUIのRadioは視覚的に隠されたinput[type=radio]を使うため、
- * 通常のクリックは親要素のlabelに遮られる。
- * inputへのdispatchEventでチェックしたあと、変更イベントも明示的に発火させる。
- */
-async function clickRadio(scope: Locator, name: string | RegExp, nth = 0) {
-  const radio = scope.getByRole("radio", { name }).nth(nth);
-  await radio.dispatchEvent("click");
 }
 
 test.describe("ゲーム作成 - ルール設定", () => {
@@ -30,7 +20,7 @@ test.describe("ゲーム作成 - ルール設定", () => {
     await openCreateMatchDrawer(page);
     const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
 
-    await clickRadio(dialog, "三麻");
+    await dialog.locator("label", { hasText: "三麻" }).click();
     await expect(dialog.getByRole("radio", { name: "三麻" })).toBeChecked();
 
     // 3人用ウマプリセット: ウマ10, ウマ20, ウマ30
@@ -71,7 +61,7 @@ test.describe("ゲーム作成 - ルール設定", () => {
     await openCreateMatchDrawer(page);
     const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
 
-    await clickRadio(dialog, "カスタム", 0);
+    await dialog.locator("label", { hasText: "カスタム" }).nth(0).click();
 
     await dialog.getByRole("spinbutton", { name: "1着" }).fill("10");
     await dialog.getByRole("spinbutton", { name: "2着" }).fill("5");
@@ -88,7 +78,7 @@ test.describe("ゲーム作成 - ルール設定", () => {
     await openCreateMatchDrawer(page);
     const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
 
-    await clickRadio(dialog, "カスタム", 0);
+    await dialog.locator("label", { hasText: "カスタム" }).nth(0).click();
 
     await dialog.getByRole("spinbutton", { name: "1着" }).fill("10");
     await dialog.getByRole("spinbutton", { name: "2着" }).fill("5");
@@ -104,7 +94,7 @@ test.describe("ゲーム作成 - ルール設定", () => {
 
     // "チップ" のラジオグループ内でカスタムを選択
     // オプションカードのカスタムは2箇所（ウマとチップ）あるので2番目
-    await clickRadio(dialog, "カスタム", 1);
+    await dialog.locator("label", { hasText: "カスタム" }).nth(1).click();
 
     await dialog.getByRole("spinbutton", { name: "カスタム" }).fill("-100");
 
@@ -139,7 +129,7 @@ test.describe("ゲーム作成 - ルール設定", () => {
     await openCreateMatchDrawer(page);
     const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
 
-    await clickRadio(dialog, "三麻");
+    await dialog.locator("label", { hasText: "三麻" }).click();
     await dialog.getByRole("button", { name: "詳細設定" }).click();
 
     await expect(
@@ -278,7 +268,7 @@ test.describe("ゲーム作成 - 完了フロー", () => {
     await openCreateMatchDrawer(page);
     const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
 
-    await clickRadio(dialog, "三麻");
+    await dialog.locator("label", { hasText: "三麻" }).click();
     await dialog.getByRole("button", { name: "プレイヤー選択へ" }).click();
 
     for (const user of [TEST_USERS.alice, TEST_USERS.bob]) {

--- a/e2e/friends.spec.ts
+++ b/e2e/friends.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { TEST_USERS } from "./helpers";
+import { fillSearchbox, TEST_USERS } from "./helpers";
 
 test.describe.configure({ mode: "serial" });
 
@@ -18,9 +18,7 @@ test.describe("フレンド管理", () => {
 
   test("ユーザーIDで検索できる", async ({ page }) => {
     await page.goto("/friends/add");
-    await page
-      .getByRole("searchbox", { name: /検索|ユーザーID/ })
-      .fill(TEST_USERS.alice.displayId);
+    await fillSearchbox(page, TEST_USERS.alice.displayId);
 
     await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
     await expect(
@@ -30,9 +28,7 @@ test.describe("フレンド管理", () => {
 
   test("名前で検索できる", async ({ page }) => {
     await page.goto("/friends/add");
-    await page
-      .getByRole("searchbox", { name: /検索|ユーザーID/ })
-      .fill(TEST_USERS.bob.name);
+    await fillSearchbox(page, TEST_USERS.bob.name);
 
     await expect(page.getByText(TEST_USERS.bob.name)).toBeVisible();
   });
@@ -41,9 +37,7 @@ test.describe("フレンド管理", () => {
     page,
   }) => {
     await page.goto("/friends/add");
-    await page
-      .getByRole("searchbox", { name: /検索|ユーザーID/ })
-      .fill("xxxxxxxxxxxxxxxxxxxx");
+    await fillSearchbox(page, "xxxxxxxxxxxxxxxxxxxx");
 
     await expect(page.getByText("見つかりませんでした")).toBeVisible();
   });
@@ -53,9 +47,7 @@ test.describe("フレンド管理", () => {
   }) => {
     // seedでaliceはフレンドとして登録されている
     await page.goto("/friends/add");
-    await page
-      .getByRole("searchbox", { name: /検索|ユーザーID/ })
-      .fill(TEST_USERS.alice.displayId);
+    await fillSearchbox(page, TEST_USERS.alice.displayId);
 
     await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
     await expect(page.getByText("追加済み")).toBeVisible();
@@ -79,9 +71,7 @@ test.describe("フレンド管理", () => {
   test("検索結果の「追加」ボタンからフレンド追加できる", async ({ page }) => {
     // 前テストで alice は削除済み
     await page.goto("/friends/add");
-    await page
-      .getByRole("searchbox", { name: /検索|ユーザーID/ })
-      .fill(TEST_USERS.alice.displayId);
+    await fillSearchbox(page, TEST_USERS.alice.displayId);
 
     await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
     await page.getByRole("button", { name: "追加", exact: true }).click();

--- a/e2e/friends.spec.ts
+++ b/e2e/friends.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+import { TEST_USERS } from "./helpers";
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("フレンド管理", () => {
+  test("フレンド検索ページが開ける", async ({ page }) => {
+    await page.goto("/friends");
+    await expect(page.getByRole("heading", { name: "フレンド" })).toBeVisible();
+
+    const addLink = page.locator('a[href="/friends/add"]').first();
+    await addLink.click();
+    await expect(page).toHaveURL(/\/friends\/add/);
+    await expect(
+      page.getByRole("heading", { name: "フレンド追加" }),
+    ).toBeVisible();
+  });
+
+  test("ユーザーIDで検索できる", async ({ page }) => {
+    await page.goto("/friends/add");
+    await page
+      .getByRole("searchbox", { name: /検索|ユーザーID/ })
+      .fill(TEST_USERS.alice.displayId);
+
+    await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
+    await expect(
+      page.getByText(`@${TEST_USERS.alice.displayId}`),
+    ).toBeVisible();
+  });
+
+  test("名前で検索できる", async ({ page }) => {
+    await page.goto("/friends/add");
+    await page
+      .getByRole("searchbox", { name: /検索|ユーザーID/ })
+      .fill(TEST_USERS.bob.name);
+
+    await expect(page.getByText(TEST_USERS.bob.name)).toBeVisible();
+  });
+
+  test("存在しないユーザーを検索すると見つかりませんと表示", async ({
+    page,
+  }) => {
+    await page.goto("/friends/add");
+    await page
+      .getByRole("searchbox", { name: /検索|ユーザーID/ })
+      .fill("xxxxxxxxxxxxxxxxxxxx");
+
+    await expect(page.getByText("見つかりませんでした")).toBeVisible();
+  });
+
+  test("フレンドとして追加済みのユーザーは「追加済み」と表示される", async ({
+    page,
+  }) => {
+    // seedでaliceはフレンドとして登録されている
+    await page.goto("/friends/add");
+    await page
+      .getByRole("searchbox", { name: /検索|ユーザーID/ })
+      .fill(TEST_USERS.alice.displayId);
+
+    await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
+    await expect(page.getByText("追加済み")).toBeVisible();
+  });
+
+  // 以下は state 変更を伴うため order 依存（削除 → 追加し直して元の状態に戻す）
+  test("フレンドメニューから削除できる", async ({ page }) => {
+    await page.goto("/friends");
+    await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
+
+    // alice の行のメニューから削除
+    const aliceRow = page
+      .getByRole("listitem")
+      .filter({ hasText: TEST_USERS.alice.name });
+    await aliceRow.getByRole("button", { name: "フレンドメニュー" }).click();
+    await page.getByRole("menuitem", { name: "削除" }).click();
+
+    await expect(page.getByText(TEST_USERS.alice.name)).not.toBeVisible();
+  });
+
+  test("検索結果の「追加」ボタンからフレンド追加できる", async ({ page }) => {
+    // 前テストで alice は削除済み
+    await page.goto("/friends/add");
+    await page
+      .getByRole("searchbox", { name: /検索|ユーザーID/ })
+      .fill(TEST_USERS.alice.displayId);
+
+    await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
+    await page.getByRole("button", { name: "追加", exact: true }).click();
+    await expect(page.getByText("追加済み")).toBeVisible();
+
+    await page.goto("/friends");
+    await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
+  });
+});

--- a/e2e/friends.spec.ts
+++ b/e2e/friends.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { fillSearchbox, TEST_USERS } from "./helpers";
+import { fillInput, TEST_USERS } from "./helpers";
 
+// 後半のテストは「削除 → 再追加で元に戻す」と順序依存になっているため、
+// 前段が失敗したら後段をスキップして DB を壊れた状態で進めないように serial を指定する。
+// （workers:1 だけでは失敗しても後続が続行されてしまう）
 test.describe.configure({ mode: "serial" });
 
 test.describe("フレンド管理", () => {
@@ -18,7 +21,10 @@ test.describe("フレンド管理", () => {
 
   test("ユーザーIDで検索できる", async ({ page }) => {
     await page.goto("/friends/add");
-    await fillSearchbox(page, TEST_USERS.alice.displayId);
+    await fillInput(
+      page.getByRole("searchbox", { name: /検索|ユーザーID/ }),
+      TEST_USERS.alice.displayId,
+    );
 
     await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
     await expect(
@@ -28,7 +34,10 @@ test.describe("フレンド管理", () => {
 
   test("名前で検索できる", async ({ page }) => {
     await page.goto("/friends/add");
-    await fillSearchbox(page, TEST_USERS.bob.name);
+    await fillInput(
+      page.getByRole("searchbox", { name: /検索|ユーザーID/ }),
+      TEST_USERS.bob.name,
+    );
 
     await expect(page.getByText(TEST_USERS.bob.name)).toBeVisible();
   });
@@ -37,7 +46,10 @@ test.describe("フレンド管理", () => {
     page,
   }) => {
     await page.goto("/friends/add");
-    await fillSearchbox(page, "xxxxxxxxxxxxxxxxxxxx");
+    await fillInput(
+      page.getByRole("searchbox", { name: /検索|ユーザーID/ }),
+      "xxxxxxxxxxxxxxxxxxxx",
+    );
 
     await expect(page.getByText("見つかりませんでした")).toBeVisible();
   });
@@ -47,7 +59,10 @@ test.describe("フレンド管理", () => {
   }) => {
     // seedでaliceはフレンドとして登録されている
     await page.goto("/friends/add");
-    await fillSearchbox(page, TEST_USERS.alice.displayId);
+    await fillInput(
+      page.getByRole("searchbox", { name: /検索|ユーザーID/ }),
+      TEST_USERS.alice.displayId,
+    );
 
     await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
     await expect(page.getByText("追加済み")).toBeVisible();
@@ -71,7 +86,10 @@ test.describe("フレンド管理", () => {
   test("検索結果の「追加」ボタンからフレンド追加できる", async ({ page }) => {
     // 前テストで alice は削除済み
     await page.goto("/friends/add");
-    await fillSearchbox(page, TEST_USERS.alice.displayId);
+    await fillInput(
+      page.getByRole("searchbox", { name: /検索|ユーザーID/ }),
+      TEST_USERS.alice.displayId,
+    );
 
     await expect(page.getByText(TEST_USERS.alice.name)).toBeVisible();
     await page.getByRole("button", { name: "追加", exact: true }).click();

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,5 @@
+import { execSync } from "node:child_process";
+
+export default function globalSetup() {
+  execSync("npx supabase db reset", { stdio: "inherit" });
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,10 +1,30 @@
+import type { Locator, Page } from "@playwright/test";
+
 /**
  * seed.sqlで事前作成されている四麻マッチのID
- * 参加プレイヤー: testuser, alice123, bob123, carol123
- * ゲーム・チップは未登録の状態
+ * 参加プレイヤー: testuser, alice123, bob123, carol123 (4人)
+ * ルール: 4人・持ち点25000・ゲーム/チップ未登録
  */
 export const SEED_MATCH_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 export const SEED_MATCH_URL = `/matches/${SEED_MATCH_ID}`;
+
+/**
+ * seed.sqlで事前作成されている三麻マッチのID
+ * 参加プレイヤー: testuser, alice123, bob123 (3人)
+ * ルール: 3人・持ち点35000・ゲーム/チップ未登録
+ */
+export const SEED_3PLAYER_MATCH_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+export const SEED_3PLAYER_MATCH_URL = `/matches/${SEED_3PLAYER_MATCH_ID}`;
+
+/**
+ * seed.sqlで事前作成されているルール人数超過マッチのID
+ * 参加プレイヤー: testuser, alice123, bob123, carol123 (4人)
+ * ルール: 3人・持ち点35000 (参加者4人 > ルール3人)
+ * ゲーム/チップ未登録
+ */
+export const SEED_OVERCAPACITY_MATCH_ID =
+  "cccccccc-cccc-cccc-cccc-cccccccccccc";
+export const SEED_OVERCAPACITY_MATCH_URL = `/matches/${SEED_OVERCAPACITY_MATCH_ID}`;
 
 /**
  * seed.sqlで用意されているテスト用ユーザー
@@ -43,4 +63,44 @@ export function randomEmail() {
 
 export function randomDisplayId() {
   return `u${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * WebKit では React Aria の controlled input に対して fill() が不安定なため、
+ * pressSequentially() を使ってキーボードイベント経由で値を入力するヘルパー群。
+ *
+ * 原因: Playwright の fill() はプログラマティックに input イベントを発火するが、
+ * WebKit では isTrusted:false のイベントを React が確実に処理しない場合がある。
+ * pressSequentially() は実際のキーボードイベント連鎖を発生させるため安定して動作する。
+ */
+
+export async function fillEmail(page: Page, email: string) {
+  const input = page.getByRole("textbox", { name: "メールアドレス" });
+  await input.click();
+  await input.pressSequentially(email);
+}
+
+export async function fillSearchbox(page: Page, value: string) {
+  const input = page.getByRole("searchbox", { name: /検索|ユーザーID/ });
+  await input.click();
+  await input.pressSequentially(value);
+}
+
+export async function fillDisplayId(page: Page, value: string) {
+  const input = page.getByRole("textbox", { name: "ユーザーID" });
+  await input.click();
+  await input.pressSequentially(value);
+}
+
+/**
+ * 既存値がある場合も考慮して triple-click で全選択してから上書きする。
+ * value が空文字の場合は Backspace で全削除する。
+ */
+export async function fillName(locator: Locator, value: string) {
+  await locator.click({ clickCount: 3 });
+  if (value === "") {
+    await locator.press("Backspace");
+  } else {
+    await locator.pressSequentially(value);
+  }
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Locator } from "@playwright/test";
 
 /**
  * seed.sqlで事前作成されている四麻マッチのID
@@ -67,40 +67,29 @@ export function randomDisplayId() {
 
 /**
  * WebKit では React Aria の controlled input に対して fill() が不安定なため、
- * pressSequentially() を使ってキーボードイベント経由で値を入力するヘルパー群。
+ * pressSequentially() を使ってキーボードイベント経由で値を入力するヘルパー。
  *
  * 原因: Playwright の fill() はプログラマティックに input イベントを発火するが、
  * WebKit では isTrusted:false のイベントを React が確実に処理しない場合がある。
  * pressSequentially() は実際のキーボードイベント連鎖を発生させるため安定して動作する。
+ *
+ * 既存値のクリアはこのヘルパーでは扱わない。テストは冪等であるべきで、
+ * 既存値がある前提のテストは呼び出し側で明示的に clearInput を呼ぶ。
  */
-
-export async function fillEmail(page: Page, email: string) {
-  const input = page.getByRole("textbox", { name: "メールアドレス" });
-  await input.click();
-  await input.pressSequentially(email);
-}
-
-export async function fillSearchbox(page: Page, value: string) {
-  const input = page.getByRole("searchbox", { name: /検索|ユーザーID/ });
-  await input.click();
-  await input.pressSequentially(value);
-}
-
-export async function fillDisplayId(page: Page, value: string) {
-  const input = page.getByRole("textbox", { name: "ユーザーID" });
-  await input.click();
-  await input.pressSequentially(value);
+export async function fillInput(locator: Locator, value: string) {
+  await locator.click();
+  await locator.pressSequentially(value);
 }
 
 /**
- * 既存値がある場合も考慮して triple-click で全選択してから上書きする。
- * value が空文字の場合は Backspace で全削除する。
+ * 入力欄の既存値を全選択して削除する。
+ *
+ * fillInput は pressSequentially でキーを順次入力するため、既存値があると
+ * 上書きではなく末尾に追記されてしまう。seed データやプロフィール初期値が
+ * 入っているフォームを操作するテストでは、入力前にこの関数で明示的に
+ * クリアしてから fillInput を呼ぶ必要がある。
  */
-export async function fillName(locator: Locator, value: string) {
+export async function clearInput(locator: Locator) {
   await locator.click({ clickCount: 3 });
-  if (value === "") {
-    await locator.press("Backspace");
-  } else {
-    await locator.pressSequentially(value);
-  }
+  await locator.press("Backspace");
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,62 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * seed.sqlで事前作成されている四麻マッチのID
+ * 参加プレイヤー: testuser, alice123, bob123, carol123
+ * ゲーム・チップは未登録の状態
+ */
+export const SEED_MATCH_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+export const SEED_MATCH_URL = `/matches/${SEED_MATCH_ID}`;
+
+/**
+ * seed.sqlで用意されているテスト用ユーザー
+ */
+export const TEST_USERS = {
+  me: {
+    email: "test@example.com",
+    password: "password123",
+    displayId: "testuser",
+    name: "テストユーザー",
+  },
+  alice: {
+    email: "alice@example.com",
+    password: "password123",
+    displayId: "alice123",
+    name: "アリス",
+  },
+  bob: {
+    email: "bob@example.com",
+    password: "password123",
+    displayId: "bob123",
+    name: "ボブ",
+  },
+  carol: {
+    email: "carol@example.com",
+    password: "password123",
+    displayId: "carol123",
+    name: "キャロル",
+  },
+} as const;
+
+export async function loginAs(
+  page: Page,
+  user: { email: string; password: string },
+) {
+  await page.goto("/login");
+  await page.getByRole("textbox", { name: "メールアドレス" }).fill(user.email);
+  await page.getByRole("textbox", { name: "パスワード" }).fill(user.password);
+  await page.getByRole("button", { name: "ログイン", exact: true }).click();
+  await page.waitForURL("/matches");
+  await page.evaluate(() => {
+    localStorage.setItem("lastVersion", "999.0.0");
+  });
+}
+
+export function randomEmail() {
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `e2e-${Date.now()}-${rand}@example.com`;
+}
+
+export function randomDisplayId() {
+  return `u${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,5 +1,3 @@
-import type { Page } from "@playwright/test";
-
 /**
  * seed.sqlで事前作成されている四麻マッチのID
  * 参加プレイヤー: testuser, alice123, bob123, carol123
@@ -37,20 +35,6 @@ export const TEST_USERS = {
     name: "キャロル",
   },
 } as const;
-
-export async function loginAs(
-  page: Page,
-  user: { email: string; password: string },
-) {
-  await page.goto("/login");
-  await page.getByRole("textbox", { name: "メールアドレス" }).fill(user.email);
-  await page.getByRole("textbox", { name: "パスワード" }).fill(user.password);
-  await page.getByRole("button", { name: "ログイン", exact: true }).click();
-  await page.waitForURL("/matches");
-  await page.evaluate(() => {
-    localStorage.setItem("lastVersion", "999.0.0");
-  });
-}
 
 export function randomEmail() {
   const rand = Math.random().toString(36).slice(2, 10);

--- a/e2e/logout.spec.ts
+++ b/e2e/logout.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * ログアウトは Supabase のセッションをサーバー側で無効化するため、
+ * 共有の storageState を破壊してしまう。
+ * playwright.config.ts の cleanup プロジェクトで最後に実行される。
+ */
+test.describe("ログアウト", () => {
+  test("ログアウトするとログインページにリダイレクトされ、再アクセスもできない", async ({
+    page,
+  }) => {
+    await page.goto("/matches");
+    await expect(page).toHaveURL("/matches");
+
+    await page.getByRole("button", { name: "プロフィールメニュー" }).click();
+    await page.getByRole("menuitem", { name: "ログアウト" }).click();
+
+    await expect(page).toHaveURL(/\/login/);
+
+    await page.goto("/matches");
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/e2e/match-detail.spec.ts
+++ b/e2e/match-detail.spec.ts
@@ -1,14 +1,14 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
-import { SEED_MATCH_URL, TEST_USERS } from "./helpers";
+import { expect, type Page, test } from "@playwright/test";
+import {
+  SEED_3PLAYER_MATCH_URL,
+  SEED_MATCH_URL,
+  SEED_OVERCAPACITY_MATCH_URL,
+  TEST_USERS,
+} from "./helpers";
 
-async function fillSpinbutton(page: Page, locator: Locator, value: string) {
-  await locator.evaluate((el: HTMLInputElement) => {
-    el.focus();
-    el.select();
-  });
-  await page.keyboard.type(value);
-  await page.keyboard.press("Tab");
-}
+// 点数入力の単位は100点単位 (e.g. "400" = 40000点)
+// 4人・持ち点25000: 合計 1000 (= 100000 / 100)
+// 3人・持ち点35000: 合計 1050 (= 105000 / 100)
 
 test.describe("成績詳細ページ", () => {
   test.beforeEach(async ({ page }) => {
@@ -50,17 +50,18 @@ test.describe("成績詳細ページ", () => {
   });
 });
 
-test.describe("ゲーム結果入力フォーム", () => {
-  async function openCreateGameDrawer(page: Page) {
+// ─────────────────────────────────────────
+// ゲーム結果入力フォーム (四麻・4人)
+// ─────────────────────────────────────────
+test.describe("ゲーム結果入力フォーム (4人)", () => {
+  async function openDrawer(page: Page) {
     await page.goto(SEED_MATCH_URL);
     await page.getByRole("button", { name: "結果を入力する" }).click();
-    await expect(
-      page.getByRole("dialog", { name: /結果入力|ゲーム/ }),
-    ).toBeVisible();
+    await expect(page.getByRole("dialog", { name: "結果入力" })).toBeVisible();
   }
 
-  test("全プレイヤーの入力欄が表示される", async ({ page }) => {
-    await openCreateGameDrawer(page);
+  test("4人分の入力欄が表示される", async ({ page }) => {
+    await openDrawer(page);
     for (const user of [
       TEST_USERS.me,
       TEST_USERS.alice,
@@ -74,67 +75,48 @@ test.describe("ゲーム結果入力フォーム", () => {
   });
 
   test("点数未入力で保存するとエラー", async ({ page }) => {
-    await openCreateGameDrawer(page);
-
+    await openDrawer(page);
     await page.getByRole("button", { name: "保存", exact: true }).click();
-
     await expect(page.getByText(/4人分の点数を入力してください/)).toBeVisible();
   });
 
   test("点数の合計が想定と異なるとエラー", async ({ page }) => {
-    await openCreateGameDrawer(page);
+    await openDrawer(page);
 
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
-      "500",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
-      "250",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
-      "250",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
-      "100",
-    );
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("500");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("250");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("250");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("100");
 
     await page.getByRole("button", { name: "保存", exact: true }).click();
-
     await expect(
       page.getByText(/点数の合計が.*点になるように入力してください/),
     ).toBeVisible();
   });
 
   test("同点がある場合は並び替えボタンが表示される", async ({ page }) => {
-    await openCreateGameDrawer(page);
+    await openDrawer(page);
 
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
-      "300",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
-      "300",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
-      "250",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
-      "150",
-    );
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("300");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("300");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("250");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("150");
 
     await expect(page.getByText(/同点/)).toBeVisible();
   });
@@ -142,92 +124,170 @@ test.describe("ゲーム結果入力フォーム", () => {
   test("0点未満のプレイヤーがいないのに飛ばした人を選ぶとエラー", async ({
     page,
   }) => {
-    await openCreateGameDrawer(page);
+    await openDrawer(page);
 
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
-      "400",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
-      "300",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
-      "200",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
-      "100",
-    );
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("400");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("300");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("200");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("100");
 
-    await page.getByRole("button", { name: /なし|飛ばした人/ }).click();
+    await page.getByRole("button", { name: "飛ばした人" }).click();
     await page.getByRole("option", { name: TEST_USERS.alice.name }).click();
 
     await page.getByRole("button", { name: "保存", exact: true }).click();
-
     await expect(
       page.getByText("0点を下回るプレイヤーがいません"),
     ).toBeVisible();
   });
 
   test("キャンセルでドロワーを閉じられる", async ({ page }) => {
-    await openCreateGameDrawer(page);
-
+    await openDrawer(page);
     await page.getByRole("button", { name: "キャンセル" }).click();
     await expect(
-      page.getByRole("dialog", { name: /結果入力/ }),
+      page.getByRole("dialog", { name: "結果入力" }),
     ).not.toBeVisible();
   });
 
-  // 書き込み系の最後に実行（ゲーム行が1件増えるがドロワー初期状態には影響しない）
-  test("3人分埋まると残りの『残り入力』ボタンが出て自動補完できる", async ({
+  // 以下は書き込みを伴うため最後に配置
+  test("4人全員を手動で入力して保存できる", async ({ page }) => {
+    await openDrawer(page);
+
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("400");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("300");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("200");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("100");
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(
+      page.getByRole("dialog", { name: "結果入力" }),
+    ).not.toBeVisible();
+  });
+
+  test("3人入力後に残り入力ボタンが出て自動補完して保存できる", async ({
     page,
   }) => {
-    await openCreateGameDrawer(page);
+    await openDrawer(page);
 
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
-      "500",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
-      "300",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
-      "100",
-    );
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("500");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("300");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("100");
 
     const autoFillBtn = page.getByRole("button", { name: "残り入力" }).first();
     await expect(autoFillBtn).toBeVisible();
     await autoFillBtn.click();
 
     await page.getByRole("button", { name: "保存", exact: true }).click();
-
     await expect(
-      page.getByRole("dialog", { name: /結果入力/ }),
+      page.getByRole("dialog", { name: "結果入力" }),
     ).not.toBeVisible();
   });
 });
 
-test.describe("チップ入力フォーム", () => {
-  async function openChipDrawer(page: Page) {
-    await page.goto(SEED_MATCH_URL);
-    await page.getByRole("button", { name: "チップを入力する" }).click();
-    await expect(page.getByRole("dialog", { name: /チップ/ })).toBeVisible();
+// ─────────────────────────────────────────
+// ゲーム結果入力フォーム (三麻・3人)
+// ─────────────────────────────────────────
+test.describe("ゲーム結果入力フォーム (3人)", () => {
+  async function openDrawer(page: Page) {
+    await page.goto(SEED_3PLAYER_MATCH_URL);
+    await page.getByRole("button", { name: "結果を入力する" }).click();
+    await expect(page.getByRole("dialog", { name: "結果入力" })).toBeVisible();
   }
 
-  test("プレイヤーごとのチップ入力欄が並んでいる", async ({ page }) => {
-    await openChipDrawer(page);
+  test("3人分の入力欄のみ表示される", async ({ page }) => {
+    await openDrawer(page);
+    for (const user of [TEST_USERS.me, TEST_USERS.alice, TEST_USERS.bob]) {
+      await expect(
+        page.getByRole("spinbutton", { name: user.name }),
+      ).toBeVisible();
+    }
+    await expect(
+      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
+    ).not.toBeVisible();
+  });
 
+  test("点数未入力で保存するとエラー", async ({ page }) => {
+    await openDrawer(page);
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(page.getByText(/3人分の点数を入力してください/)).toBeVisible();
+  });
+
+  test("3人全員を手動で入力して保存できる", async ({ page }) => {
+    await openDrawer(page);
+
+    // 3人・持ち点35000 → 合計1050 (= 105000 / 100)
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("450");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("350");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("250");
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(
+      page.getByRole("dialog", { name: "結果入力" }),
+    ).not.toBeVisible();
+  });
+
+  test("2人入力後に残り入力ボタンが出て自動補完して保存できる", async ({
+    page,
+  }) => {
+    await openDrawer(page);
+
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("450");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("350");
+
+    const autoFillBtn = page.getByRole("button", { name: "残り入力" }).first();
+    await expect(autoFillBtn).toBeVisible();
+    await autoFillBtn.click();
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(
+      page.getByRole("dialog", { name: "結果入力" }),
+    ).not.toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────
+// ゲーム結果入力フォーム (三麻ルール・参加者4人=超過)
+// ─────────────────────────────────────────
+test.describe("ゲーム結果入力フォーム (ルール人数超過: 三麻ルール・4人参加)", () => {
+  async function openDrawer(page: Page) {
+    await page.goto(SEED_OVERCAPACITY_MATCH_URL);
+    await page.getByRole("button", { name: "結果を入力する" }).click();
+    await expect(page.getByRole("dialog", { name: "結果入力" })).toBeVisible();
+  }
+
+  test("参加者全員(4人)の入力欄が表示される", async ({ page }) => {
+    await openDrawer(page);
     for (const user of [
       TEST_USERS.me,
       TEST_USERS.alice,
@@ -240,90 +300,262 @@ test.describe("チップ入力フォーム", () => {
     }
   });
 
-  test("チップ合計が0以外だとエラー", async ({ page }) => {
-    await openChipDrawer(page);
+  test("全員(4人)入力するとルール人数(3人)と合わずエラー", async ({ page }) => {
+    await openDrawer(page);
 
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
-      "5",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
-      "3",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
-      "-2",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
-      "-1",
-    );
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("450");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("350");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("250");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("0");
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(page.getByText(/3人分の点数を入力してください/)).toBeVisible();
+  });
+
+  test("ルール人数(3人)分だけ入力して残りを空欄のまま保存できる", async ({
+    page,
+  }) => {
+    await openDrawer(page);
+
+    // carol は入力しない（空欄 = undefined → 集計対象外）
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("450");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("350");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("250");
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(
+      page.getByRole("dialog", { name: "結果入力" }),
+    ).not.toBeVisible();
+  });
+
+  test("2人入力後に残り入力ボタンが出て自動補完できる（残り1人は空欄のまま保存）", async ({
+    page,
+  }) => {
+    await openDrawer(page);
+
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.me.name })
+      .fill("450");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("350");
+
+    const autoFillBtn = page.getByRole("button", { name: "残り入力" }).first();
+    await expect(autoFillBtn).toBeVisible();
+    await autoFillBtn.click();
+
+    // 自動補完後: me=450, alice=350, bob=250(自動), carol=空欄 → 合計1050, 3人分 ✓
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(
+      page.getByRole("dialog", { name: "結果入力" }),
+    ).not.toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────
+// チップ入力フォーム (四麻・4人)
+// ─────────────────────────────────────────
+test.describe("チップ入力フォーム (4人)", () => {
+  async function openDrawer(page: Page) {
+    await page.goto(SEED_MATCH_URL);
+    await page.getByRole("button", { name: "チップを入力する" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "チップ入力" }),
+    ).toBeVisible();
+  }
+
+  test("4人分の入力欄が表示される", async ({ page }) => {
+    await openDrawer(page);
+    for (const user of [
+      TEST_USERS.me,
+      TEST_USERS.alice,
+      TEST_USERS.bob,
+      TEST_USERS.carol,
+    ]) {
+      await expect(
+        page.getByRole("spinbutton", { name: user.name }),
+      ).toBeVisible();
+    }
+  });
+
+  test("チップ合計が0以外だとドロワーが閉じない", async ({ page }) => {
+    await openDrawer(page);
+
+    await page.getByRole("spinbutton", { name: TEST_USERS.me.name }).fill("5");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("3");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("-2");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("-1");
 
     await page.getByRole("button", { name: "保存", exact: true }).click();
 
-    // 合計が合わないためドロワーは閉じずに留まる
-    await expect(page.getByRole("dialog", { name: /チップ/ })).toBeVisible();
+    // 合計5 ≠ 0 のためエラー、ドロワーは閉じない
+    await expect(
+      page.getByRole("dialog", { name: "チップ入力" }),
+    ).toBeVisible();
   });
 
-  test("3人分埋めると『残り入力』ボタンが出る", async ({ page }) => {
-    await openChipDrawer(page);
+  test("3人入力後に残り入力ボタンが出る", async ({ page }) => {
+    await openDrawer(page);
 
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
-      "5",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
-      "-2",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
-      "-2",
-    );
+    // 前のテストで carol のチップが保存されている場合に備えてクリア
     await page
       .getByRole("spinbutton", { name: TEST_USERS.carol.name })
       .fill("");
+    await page.getByRole("spinbutton", { name: TEST_USERS.me.name }).fill("5");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("-2");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("-2");
 
     await expect(page.getByRole("button", { name: "残り入力" })).toBeVisible();
   });
 
-  // 書き込み系の最後に実行（これ以降チップ値が保存されるため）
+  // 書き込み系は最後に配置
   test("合計0で保存するとドロワーが閉じる", async ({ page }) => {
-    await openChipDrawer(page);
+    await openDrawer(page);
 
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
-      "5",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
-      "-2",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
-      "-2",
-    );
-    await fillSpinbutton(
-      page,
-      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
-      "-1",
-    );
+    await page.getByRole("spinbutton", { name: TEST_USERS.me.name }).fill("5");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("-2");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("-2");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("-1");
 
     await page.getByRole("button", { name: "保存", exact: true }).click();
-
     await expect(
-      page.getByRole("dialog", { name: /チップ/ }),
+      page.getByRole("dialog", { name: "チップ入力" }),
+    ).not.toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────
+// チップ入力フォーム (三麻・3人)
+// ─────────────────────────────────────────
+test.describe("チップ入力フォーム (3人)", () => {
+  async function openDrawer(page: Page) {
+    await page.goto(SEED_3PLAYER_MATCH_URL);
+    await page.getByRole("button", { name: "チップを入力する" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "チップ入力" }),
+    ).toBeVisible();
+  }
+
+  test("3人分の入力欄のみ表示される", async ({ page }) => {
+    await openDrawer(page);
+    for (const user of [TEST_USERS.me, TEST_USERS.alice, TEST_USERS.bob]) {
+      await expect(
+        page.getByRole("spinbutton", { name: user.name }),
+      ).toBeVisible();
+    }
+    await expect(
+      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
+    ).not.toBeVisible();
+  });
+
+  test("2人入力後に残り入力ボタンが出る", async ({ page }) => {
+    await openDrawer(page);
+
+    // 前のテストで bob のチップが保存されている場合に備えてクリア
+    await page.getByRole("spinbutton", { name: TEST_USERS.bob.name }).fill("");
+    await page.getByRole("spinbutton", { name: TEST_USERS.me.name }).fill("5");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("-2");
+
+    await expect(page.getByRole("button", { name: "残り入力" })).toBeVisible();
+  });
+
+  test("合計0で保存するとドロワーが閉じる", async ({ page }) => {
+    await openDrawer(page);
+
+    await page.getByRole("spinbutton", { name: TEST_USERS.me.name }).fill("5");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("-2");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("-3");
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(
+      page.getByRole("dialog", { name: "チップ入力" }),
+    ).not.toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────
+// チップ入力フォーム (三麻ルール・参加者4人=超過)
+// ─────────────────────────────────────────
+test.describe("チップ入力フォーム (ルール人数超過: 三麻ルール・4人参加)", () => {
+  async function openDrawer(page: Page) {
+    await page.goto(SEED_OVERCAPACITY_MATCH_URL);
+    await page.getByRole("button", { name: "チップを入力する" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "チップ入力" }),
+    ).toBeVisible();
+  }
+
+  test("ルール人数に関係なく参加者全員(4人)の入力欄が表示される", async ({
+    page,
+  }) => {
+    await openDrawer(page);
+    for (const user of [
+      TEST_USERS.me,
+      TEST_USERS.alice,
+      TEST_USERS.bob,
+      TEST_USERS.carol,
+    ]) {
+      await expect(
+        page.getByRole("spinbutton", { name: user.name }),
+      ).toBeVisible();
+    }
+  });
+
+  test("全参加者(4人)の合計が0で保存するとドロワーが閉じる", async ({
+    page,
+  }) => {
+    await openDrawer(page);
+
+    await page.getByRole("spinbutton", { name: TEST_USERS.me.name }).fill("5");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.alice.name })
+      .fill("-2");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.bob.name })
+      .fill("-2");
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("-1");
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(
+      page.getByRole("dialog", { name: "チップ入力" }),
     ).not.toBeVisible();
   });
 });

--- a/e2e/match-detail.spec.ts
+++ b/e2e/match-detail.spec.ts
@@ -1,19 +1,13 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import { SEED_MATCH_URL, TEST_USERS } from "./helpers";
 
-async function fillSpinbutton(locator: Locator, value: string) {
-  await locator.scrollIntoViewIfNeeded();
-  // React stateに反映させるためnativeInputValueSetter経由で入力し、input/changeを発火
-  await locator.evaluate((el, v) => {
-    const input = el as HTMLInputElement;
-    const setter = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype,
-      "value",
-    )?.set;
-    setter?.call(input, v);
-    input.dispatchEvent(new Event("input", { bubbles: true }));
-    input.dispatchEvent(new Event("change", { bubbles: true }));
-  }, value);
+async function fillSpinbutton(page: Page, locator: Locator, value: string) {
+  await locator.evaluate((el: HTMLInputElement) => {
+    el.focus();
+    el.select();
+  });
+  await page.keyboard.type(value);
+  await page.keyboard.press("Tab");
 }
 
 test.describe("成績詳細ページ", () => {
@@ -91,18 +85,22 @@ test.describe("ゲーム結果入力フォーム", () => {
     await openCreateGameDrawer(page);
 
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
       "500",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
       "250",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
       "250",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
       "100",
     );
@@ -118,18 +116,22 @@ test.describe("ゲーム結果入力フォーム", () => {
     await openCreateGameDrawer(page);
 
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
       "300",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
       "300",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
       "250",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
       "150",
     );
@@ -143,18 +145,22 @@ test.describe("ゲーム結果入力フォーム", () => {
     await openCreateGameDrawer(page);
 
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
       "400",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
       "300",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
       "200",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
       "100",
     );
@@ -185,14 +191,17 @@ test.describe("ゲーム結果入力フォーム", () => {
     await openCreateGameDrawer(page);
 
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
       "500",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
       "300",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
       "100",
     );
@@ -235,18 +244,22 @@ test.describe("チップ入力フォーム", () => {
     await openChipDrawer(page);
 
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
       "5",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
       "3",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
       "-2",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
       "-1",
     );
@@ -261,17 +274,23 @@ test.describe("チップ入力フォーム", () => {
     await openChipDrawer(page);
 
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
       "5",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
       "-2",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
       "-2",
     );
+    await page
+      .getByRole("spinbutton", { name: TEST_USERS.carol.name })
+      .fill("");
 
     await expect(page.getByRole("button", { name: "残り入力" })).toBeVisible();
   });
@@ -281,18 +300,22 @@ test.describe("チップ入力フォーム", () => {
     await openChipDrawer(page);
 
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
       "5",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
       "-2",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
       "-2",
     );
     await fillSpinbutton(
+      page,
       page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
       "-1",
     );

--- a/e2e/match-detail.spec.ts
+++ b/e2e/match-detail.spec.ts
@@ -1,0 +1,306 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { SEED_MATCH_URL, TEST_USERS } from "./helpers";
+
+async function fillSpinbutton(locator: Locator, value: string) {
+  await locator.scrollIntoViewIfNeeded();
+  // React stateに反映させるためnativeInputValueSetter経由で入力し、input/changeを発火
+  await locator.evaluate((el, v) => {
+    const input = el as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, v);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  }, value);
+}
+
+test.describe("成績詳細ページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(SEED_MATCH_URL);
+  });
+
+  test("ヘッダーと結果入力・チップ入力・ルール確認ボタンが表示される", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole("button", { name: "結果を入力する" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "チップを入力する" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "ルールを確認" }),
+    ).toBeVisible();
+  });
+
+  test("ルールモーダルを開ける", async ({ page }) => {
+    await page.getByRole("button", { name: "ルールを確認" }).click();
+    const modal = page.getByRole("dialog", { name: "ルール" });
+    await expect(modal).toBeVisible();
+    await expect(modal.getByText("プレイ人数")).toBeVisible();
+    await expect(modal.getByText("4人")).toBeVisible();
+  });
+
+  test("プレイヤー追加ドロワーを開ける", async ({ page }) => {
+    await page.getByRole("button", { name: "プレイヤーを追加" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "プレイヤー選択" }),
+    ).toBeVisible();
+  });
+
+  test("戻るボタンで/matchesに戻れる", async ({ page }) => {
+    await page.getByRole("link", { name: "戻る" }).click();
+    await expect(page).toHaveURL("/matches");
+  });
+});
+
+test.describe("ゲーム結果入力フォーム", () => {
+  async function openCreateGameDrawer(page: Page) {
+    await page.goto(SEED_MATCH_URL);
+    await page.getByRole("button", { name: "結果を入力する" }).click();
+    await expect(
+      page.getByRole("dialog", { name: /結果入力|ゲーム/ }),
+    ).toBeVisible();
+  }
+
+  test("全プレイヤーの入力欄が表示される", async ({ page }) => {
+    await openCreateGameDrawer(page);
+    for (const user of [
+      TEST_USERS.me,
+      TEST_USERS.alice,
+      TEST_USERS.bob,
+      TEST_USERS.carol,
+    ]) {
+      await expect(
+        page.getByRole("spinbutton", { name: user.name }),
+      ).toBeVisible();
+    }
+  });
+
+  test("点数未入力で保存するとエラー", async ({ page }) => {
+    await openCreateGameDrawer(page);
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    await expect(page.getByText(/4人分の点数を入力してください/)).toBeVisible();
+  });
+
+  test("点数の合計が想定と異なるとエラー", async ({ page }) => {
+    await openCreateGameDrawer(page);
+
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
+      "500",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
+      "250",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
+      "250",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
+      "100",
+    );
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    await expect(
+      page.getByText(/点数の合計が.*点になるように入力してください/),
+    ).toBeVisible();
+  });
+
+  test("同点がある場合は並び替えボタンが表示される", async ({ page }) => {
+    await openCreateGameDrawer(page);
+
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
+      "300",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
+      "300",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
+      "250",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
+      "150",
+    );
+
+    await expect(page.getByText(/同点/)).toBeVisible();
+  });
+
+  test("0点未満のプレイヤーがいないのに飛ばした人を選ぶとエラー", async ({
+    page,
+  }) => {
+    await openCreateGameDrawer(page);
+
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
+      "400",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
+      "300",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
+      "200",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
+      "100",
+    );
+
+    await page.getByRole("button", { name: /なし|飛ばした人/ }).click();
+    await page.getByRole("option", { name: TEST_USERS.alice.name }).click();
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    await expect(
+      page.getByText("0点を下回るプレイヤーがいません"),
+    ).toBeVisible();
+  });
+
+  test("キャンセルでドロワーを閉じられる", async ({ page }) => {
+    await openCreateGameDrawer(page);
+
+    await page.getByRole("button", { name: "キャンセル" }).click();
+    await expect(
+      page.getByRole("dialog", { name: /結果入力/ }),
+    ).not.toBeVisible();
+  });
+
+  // 書き込み系の最後に実行（ゲーム行が1件増えるがドロワー初期状態には影響しない）
+  test("3人分埋まると残りの『残り入力』ボタンが出て自動補完できる", async ({
+    page,
+  }) => {
+    await openCreateGameDrawer(page);
+
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
+      "500",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
+      "300",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
+      "100",
+    );
+
+    const autoFillBtn = page.getByRole("button", { name: "残り入力" }).first();
+    await expect(autoFillBtn).toBeVisible();
+    await autoFillBtn.click();
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    await expect(
+      page.getByRole("dialog", { name: /結果入力/ }),
+    ).not.toBeVisible();
+  });
+});
+
+test.describe("チップ入力フォーム", () => {
+  async function openChipDrawer(page: Page) {
+    await page.goto(SEED_MATCH_URL);
+    await page.getByRole("button", { name: "チップを入力する" }).click();
+    await expect(page.getByRole("dialog", { name: /チップ/ })).toBeVisible();
+  }
+
+  test("プレイヤーごとのチップ入力欄が並んでいる", async ({ page }) => {
+    await openChipDrawer(page);
+
+    for (const user of [
+      TEST_USERS.me,
+      TEST_USERS.alice,
+      TEST_USERS.bob,
+      TEST_USERS.carol,
+    ]) {
+      await expect(
+        page.getByRole("spinbutton", { name: user.name }),
+      ).toBeVisible();
+    }
+  });
+
+  test("チップ合計が0以外だとエラー", async ({ page }) => {
+    await openChipDrawer(page);
+
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
+      "5",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
+      "3",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
+      "-2",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
+      "-1",
+    );
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    // 合計が合わないためドロワーは閉じずに留まる
+    await expect(page.getByRole("dialog", { name: /チップ/ })).toBeVisible();
+  });
+
+  test("3人分埋めると『残り入力』ボタンが出る", async ({ page }) => {
+    await openChipDrawer(page);
+
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
+      "5",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
+      "-2",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
+      "-2",
+    );
+
+    await expect(page.getByRole("button", { name: "残り入力" })).toBeVisible();
+  });
+
+  // 書き込み系の最後に実行（これ以降チップ値が保存されるため）
+  test("合計0で保存するとドロワーが閉じる", async ({ page }) => {
+    await openChipDrawer(page);
+
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.me.name }),
+      "5",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.alice.name }),
+      "-2",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.bob.name }),
+      "-2",
+    );
+    await fillSpinbutton(
+      page.getByRole("spinbutton", { name: TEST_USERS.carol.name }),
+      "-1",
+    );
+
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    await expect(
+      page.getByRole("dialog", { name: /チップ/ }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/matches.spec.ts
+++ b/e2e/matches.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("成績表 一覧ページ", () => {
+  test("ページが表示される", async ({ page }) => {
+    await page.goto("/matches");
+    await expect(page.getByRole("heading", { name: "成績表" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "ゲームを始める" }),
+    ).toBeVisible();
+  });
+
+  test("ゲームを始めるボタンでドロワーが開く", async ({ page }) => {
+    await page.goto("/matches");
+    await page.getByRole("button", { name: "ゲームを始める" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+    await expect(dialog).toBeVisible();
+
+    // ステッパー: 1. ルール設定, 2. プレイヤー選択
+    await expect(dialog.getByText("ルール設定", { exact: true })).toBeVisible();
+    await expect(
+      dialog.getByText("プレイヤー選択", { exact: true }),
+    ).toBeVisible();
+  });
+
+  test("ドロワーをキャンセルで閉じられる", async ({ page }) => {
+    await page.goto("/matches");
+    await page.getByRole("button", { name: "ゲームを始める" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "ゲーム作成" });
+    await expect(dialog).toBeVisible();
+
+    await page.getByRole("button", { name: "キャンセル" }).click();
+    await expect(dialog).not.toBeVisible();
+  });
+});

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { fillName, TEST_USERS } from "./helpers";
+import { clearInput, fillInput, TEST_USERS } from "./helpers";
 
 test.describe("プロフィール編集", () => {
   test("プロフィール情報が表示されている", async ({ page }) => {
@@ -25,7 +25,9 @@ test.describe("プロフィール編集", () => {
   test("名前を空にするとバリデーションエラー", async ({ page }) => {
     await page.goto("/profile");
 
-    await fillName(page.getByRole("textbox", { name: "名前" }), "");
+    // 名前欄には seed の初期値が入っているため、空文字での送信を再現するには
+    // 明示的に clearInput でクリアする必要がある。
+    await clearInput(page.getByRole("textbox", { name: "名前" }));
     await page.getByRole("button", { name: "保存", exact: true }).click();
 
     await expect(page.getByText("名前を入力してください")).toBeVisible();
@@ -34,7 +36,10 @@ test.describe("プロフィール編集", () => {
   test("名前が長すぎるとバリデーションエラー", async ({ page }) => {
     await page.goto("/profile");
 
-    await fillName(
+    // 名前欄には seed の初期値が入っているため、新しい値だけを純粋に検証するには
+    // 入力前に clearInput でクリアする（pressSequentially は末尾追記になるため）。
+    await clearInput(page.getByRole("textbox", { name: "名前" }));
+    await fillInput(
       page.getByRole("textbox", { name: "名前" }),
       "あ".repeat(13),
     );
@@ -51,14 +56,18 @@ test.describe("プロフィール編集", () => {
     const originalName = TEST_USERS.me.name;
     const newName = "テストユーザー改";
 
-    await fillName(page.getByRole("textbox", { name: "名前" }), newName);
+    // 名前欄には seed/保存済みの初期値が入っているため、上書きするには
+    // 入力前に clearInput でクリアする（pressSequentially は末尾追記になるため）。
+    await clearInput(page.getByRole("textbox", { name: "名前" }));
+    await fillInput(page.getByRole("textbox", { name: "名前" }), newName);
     await page.getByRole("button", { name: "保存", exact: true }).click();
 
     await expect(page.getByText("プロフィールを更新しました")).toBeVisible();
 
     // ページを再読み込みして Conform の状態をリセットしてから元の名前に戻す
     await page.goto("/profile");
-    await fillName(page.getByRole("textbox", { name: "名前" }), originalName);
+    await clearInput(page.getByRole("textbox", { name: "名前" }));
+    await fillInput(page.getByRole("textbox", { name: "名前" }), originalName);
     await page.getByRole("button", { name: "保存", exact: true }).click();
     await expect(page.getByText("プロフィールを更新しました")).toBeVisible();
   });

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+import { TEST_USERS } from "./helpers";
+
+test.describe("プロフィール編集", () => {
+  test("プロフィール情報が表示されている", async ({ page }) => {
+    await page.goto("/profile");
+    await expect(page).toHaveURL("/profile");
+
+    await expect(page.getByRole("textbox", { name: "ユーザーID" })).toHaveValue(
+      TEST_USERS.me.displayId,
+    );
+    await expect(page.getByRole("textbox", { name: "名前" })).toHaveValue(
+      TEST_USERS.me.name,
+    );
+  });
+
+  test("ユーザーIDは変更できない（readonly）", async ({ page }) => {
+    await page.goto("/profile");
+
+    const displayIdInput = page.getByRole("textbox", { name: "ユーザーID" });
+    await expect(displayIdInput).toBeDisabled();
+    await expect(page.getByText("ユーザーIDは変更できません")).toBeVisible();
+  });
+
+  test("名前を空にするとバリデーションエラー", async ({ page }) => {
+    await page.goto("/profile");
+
+    await page.getByRole("textbox", { name: "名前" }).fill("");
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    await expect(page.getByText("名前を入力してください")).toBeVisible();
+  });
+
+  test("名前が長すぎるとバリデーションエラー", async ({ page }) => {
+    await page.goto("/profile");
+
+    await page.getByRole("textbox", { name: "名前" }).fill("あ".repeat(13));
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    await expect(
+      page.getByText("名前は12文字以内で入力してください"),
+    ).toBeVisible();
+  });
+
+  test("名前を変更して保存するとトーストが表示される", async ({ page }) => {
+    await page.goto("/profile");
+
+    const originalName = TEST_USERS.me.name;
+    const newName = "テストユーザー改";
+
+    await page.getByRole("textbox", { name: "名前" }).fill(newName);
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+
+    await expect(page.getByText("プロフィールを更新しました")).toBeVisible();
+
+    // 状態を元に戻す
+    await page.getByRole("textbox", { name: "名前" }).fill(originalName);
+    await page.getByRole("button", { name: "保存", exact: true }).click();
+    await expect(page.getByText("プロフィールを更新しました")).toBeVisible();
+  });
+});

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { TEST_USERS } from "./helpers";
+import { fillName, TEST_USERS } from "./helpers";
 
 test.describe("プロフィール編集", () => {
   test("プロフィール情報が表示されている", async ({ page }) => {
@@ -25,7 +25,7 @@ test.describe("プロフィール編集", () => {
   test("名前を空にするとバリデーションエラー", async ({ page }) => {
     await page.goto("/profile");
 
-    await page.getByRole("textbox", { name: "名前" }).fill("");
+    await fillName(page.getByRole("textbox", { name: "名前" }), "");
     await page.getByRole("button", { name: "保存", exact: true }).click();
 
     await expect(page.getByText("名前を入力してください")).toBeVisible();
@@ -34,7 +34,10 @@ test.describe("プロフィール編集", () => {
   test("名前が長すぎるとバリデーションエラー", async ({ page }) => {
     await page.goto("/profile");
 
-    await page.getByRole("textbox", { name: "名前" }).fill("あ".repeat(13));
+    await fillName(
+      page.getByRole("textbox", { name: "名前" }),
+      "あ".repeat(13),
+    );
     await page.getByRole("button", { name: "保存", exact: true }).click();
 
     await expect(
@@ -48,13 +51,14 @@ test.describe("プロフィール編集", () => {
     const originalName = TEST_USERS.me.name;
     const newName = "テストユーザー改";
 
-    await page.getByRole("textbox", { name: "名前" }).fill(newName);
+    await fillName(page.getByRole("textbox", { name: "名前" }), newName);
     await page.getByRole("button", { name: "保存", exact: true }).click();
 
     await expect(page.getByText("プロフィールを更新しました")).toBeVisible();
 
-    // 状態を元に戻す
-    await page.getByRole("textbox", { name: "名前" }).fill(originalName);
+    // ページを再読み込みして Conform の状態をリセットしてから元の名前に戻す
+    await page.goto("/profile");
+    await fillName(page.getByRole("textbox", { name: "名前" }), originalName);
     await page.getByRole("button", { name: "保存", exact: true }).click();
     await expect(page.getByText("プロフィールを更新しました")).toBeVisible();
   });

--- a/e2e/register.spec.ts
+++ b/e2e/register.spec.ts
@@ -1,11 +1,15 @@
 import { expect, type Page, test } from "@playwright/test";
-import { randomDisplayId, randomEmail } from "./helpers";
+import {
+  fillDisplayId,
+  fillEmail,
+  fillName,
+  randomDisplayId,
+  randomEmail,
+} from "./helpers";
 
 async function createFreshSignedUpUser(page: Page) {
   await page.goto("/sign-up");
-  await page
-    .getByRole("textbox", { name: "メールアドレス" })
-    .fill(randomEmail());
+  await fillEmail(page, randomEmail());
   await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
   await page.getByRole("button", { name: "新規登録", exact: true }).click();
   await page.waitForURL(/\/register/);
@@ -26,22 +30,20 @@ test.describe("ユーザー情報登録 - バリデーション", () => {
   test("ユーザーIDを入力せずに送信するとバリデーションエラー", async ({
     page,
   }) => {
-    await page.getByRole("textbox", { name: "名前" }).fill("テスト");
+    await fillName(page.getByRole("textbox", { name: "名前" }), "テスト");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(page.getByText("ユーザーIDを入力してください")).toBeVisible();
   });
 
   test("名前を入力せずに送信するとバリデーションエラー", async ({ page }) => {
-    await page
-      .getByRole("textbox", { name: "ユーザーID" })
-      .fill(randomDisplayId());
+    await fillDisplayId(page, randomDisplayId());
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(page.getByText("名前を入力してください")).toBeVisible();
   });
 
   test("ユーザーIDが短いとバリデーションエラー", async ({ page }) => {
-    await page.getByRole("textbox", { name: "ユーザーID" }).fill("abc");
-    await page.getByRole("textbox", { name: "名前" }).fill("テスト");
+    await fillDisplayId(page, "abc");
+    await fillName(page.getByRole("textbox", { name: "名前" }), "テスト");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(
       page.getByText("ユーザーIDは4文字以上で入力してください"),
@@ -49,10 +51,8 @@ test.describe("ユーザー情報登録 - バリデーション", () => {
   });
 
   test("ユーザーIDが長すぎるとバリデーションエラー", async ({ page }) => {
-    await page
-      .getByRole("textbox", { name: "ユーザーID" })
-      .fill("a".repeat(13));
-    await page.getByRole("textbox", { name: "名前" }).fill("テスト");
+    await fillDisplayId(page, "a".repeat(13));
+    await fillName(page.getByRole("textbox", { name: "名前" }), "テスト");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(
       page.getByText("ユーザーIDは12文字以内で入力してください"),
@@ -62,8 +62,8 @@ test.describe("ユーザー情報登録 - バリデーション", () => {
   test("ユーザーIDに半角英数字以外を含むとバリデーションエラー", async ({
     page,
   }) => {
-    await page.getByRole("textbox", { name: "ユーザーID" }).fill("ユーザー");
-    await page.getByRole("textbox", { name: "名前" }).fill("テスト");
+    await fillDisplayId(page, "ユーザー");
+    await fillName(page.getByRole("textbox", { name: "名前" }), "テスト");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(
       page.getByText("ユーザーIDは半角英数字のみで入力してください"),
@@ -71,17 +71,18 @@ test.describe("ユーザー情報登録 - バリデーション", () => {
   });
 
   test("すでに使われているユーザーIDを指定するとエラー", async ({ page }) => {
-    await page.getByRole("textbox", { name: "ユーザーID" }).fill("testuser");
-    await page.getByRole("textbox", { name: "名前" }).fill("別ユーザー");
+    await fillDisplayId(page, "testuser");
+    await fillName(page.getByRole("textbox", { name: "名前" }), "別ユーザー");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(page.getByText("このIDは既に使用されています")).toBeVisible();
   });
 
   test("名前が長すぎるとバリデーションエラー", async ({ page }) => {
-    await page
-      .getByRole("textbox", { name: "ユーザーID" })
-      .fill(randomDisplayId());
-    await page.getByRole("textbox", { name: "名前" }).fill("あ".repeat(13));
+    await fillDisplayId(page, randomDisplayId());
+    await fillName(
+      page.getByRole("textbox", { name: "名前" }),
+      "あ".repeat(13),
+    );
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(
       page.getByText("名前は12文字以内で入力してください"),
@@ -99,10 +100,8 @@ test.describe("ユーザー情報登録 - 副作用を伴うフロー", () => {
   test("正しい情報で登録すると /matches に遷移する", async ({ page }) => {
     await createFreshSignedUpUser(page);
 
-    await page
-      .getByRole("textbox", { name: "ユーザーID" })
-      .fill(randomDisplayId());
-    await page.getByRole("textbox", { name: "名前" }).fill("新規ユーザー");
+    await fillDisplayId(page, randomDisplayId());
+    await fillName(page.getByRole("textbox", { name: "名前" }), "新規ユーザー");
     await page.getByRole("button", { name: "決定", exact: true }).click();
 
     await expect(page).toHaveURL("/matches");

--- a/e2e/register.spec.ts
+++ b/e2e/register.spec.ts
@@ -1,0 +1,127 @@
+import { expect, type Page, test } from "@playwright/test";
+import { randomDisplayId, randomEmail } from "./helpers";
+
+async function createFreshSignedUpUser(page: Page) {
+  await page.goto("/sign-up");
+  await page
+    .getByRole("textbox", { name: "メールアドレス" })
+    .fill(randomEmail());
+  await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+  await page.getByRole("button", { name: "新規登録", exact: true }).click();
+  await page.waitForURL(/\/register/);
+}
+
+/**
+ * プロフィール未登録ユーザーのstorageStateを使い、毎回サインアップせず /register に直接アクセスする。
+ * いずれもフォームのバリデーション確認のみでプロフィール情報は保存しないため、
+ * seed ユーザーを使い回しても汚染されない。
+ */
+test.describe("ユーザー情報登録 - バリデーション", () => {
+  test.use({ storageState: "e2e/.auth/unregistered.json" });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/register");
+  });
+
+  test("ユーザーIDを入力せずに送信するとバリデーションエラー", async ({
+    page,
+  }) => {
+    await page.getByRole("textbox", { name: "名前" }).fill("テスト");
+    await page.getByRole("button", { name: "決定", exact: true }).click();
+    await expect(page.getByText("ユーザーIDを入力してください")).toBeVisible();
+  });
+
+  test("名前を入力せずに送信するとバリデーションエラー", async ({ page }) => {
+    await page
+      .getByRole("textbox", { name: "ユーザーID" })
+      .fill(randomDisplayId());
+    await page.getByRole("button", { name: "決定", exact: true }).click();
+    await expect(page.getByText("名前を入力してください")).toBeVisible();
+  });
+
+  test("ユーザーIDが短いとバリデーションエラー", async ({ page }) => {
+    await page.getByRole("textbox", { name: "ユーザーID" }).fill("abc");
+    await page.getByRole("textbox", { name: "名前" }).fill("テスト");
+    await page.getByRole("button", { name: "決定", exact: true }).click();
+    await expect(
+      page.getByText("ユーザーIDは4文字以上で入力してください"),
+    ).toBeVisible();
+  });
+
+  test("ユーザーIDが長すぎるとバリデーションエラー", async ({ page }) => {
+    await page
+      .getByRole("textbox", { name: "ユーザーID" })
+      .fill("a".repeat(13));
+    await page.getByRole("textbox", { name: "名前" }).fill("テスト");
+    await page.getByRole("button", { name: "決定", exact: true }).click();
+    await expect(
+      page.getByText("ユーザーIDは12文字以内で入力してください"),
+    ).toBeVisible();
+  });
+
+  test("ユーザーIDに半角英数字以外を含むとバリデーションエラー", async ({
+    page,
+  }) => {
+    await page.getByRole("textbox", { name: "ユーザーID" }).fill("ユーザー");
+    await page.getByRole("textbox", { name: "名前" }).fill("テスト");
+    await page.getByRole("button", { name: "決定", exact: true }).click();
+    await expect(
+      page.getByText("ユーザーIDは半角英数字のみで入力してください"),
+    ).toBeVisible();
+  });
+
+  test("すでに使われているユーザーIDを指定するとエラー", async ({ page }) => {
+    await page.getByRole("textbox", { name: "ユーザーID" }).fill("testuser");
+    await page.getByRole("textbox", { name: "名前" }).fill("別ユーザー");
+    await page.getByRole("button", { name: "決定", exact: true }).click();
+    await expect(page.getByText("このIDは既に使用されています")).toBeVisible();
+  });
+
+  test("名前が長すぎるとバリデーションエラー", async ({ page }) => {
+    await page
+      .getByRole("textbox", { name: "ユーザーID" })
+      .fill(randomDisplayId());
+    await page.getByRole("textbox", { name: "名前" }).fill("あ".repeat(13));
+    await page.getByRole("button", { name: "決定", exact: true }).click();
+    await expect(
+      page.getByText("名前は12文字以内で入力してください"),
+    ).toBeVisible();
+  });
+});
+
+/**
+ * プロフィール登録/ログアウトはユーザー状態を変化させるため、
+ * テスト毎に新規サインアップしたユーザーを使う。
+ */
+test.describe("ユーザー情報登録 - 副作用を伴うフロー", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("正しい情報で登録すると /matches に遷移する", async ({ page }) => {
+    await createFreshSignedUpUser(page);
+
+    await page
+      .getByRole("textbox", { name: "ユーザーID" })
+      .fill(randomDisplayId());
+    await page.getByRole("textbox", { name: "名前" }).fill("新規ユーザー");
+    await page.getByRole("button", { name: "決定", exact: true }).click();
+
+    await expect(page).toHaveURL("/matches");
+  });
+
+  test("登録ページからログアウトするとログインページへ", async ({ page }) => {
+    await createFreshSignedUpUser(page);
+
+    await page.getByRole("button", { name: "ログアウト" }).click();
+
+    await expect(page).toHaveURL(/\/login/);
+  });
+});
+
+test.describe("登録済みユーザーの /register アクセス", () => {
+  test("登録済みユーザーが/registerに直接アクセスすると/matchesにリダイレクト", async ({
+    page,
+  }) => {
+    await page.goto("/register");
+    await expect(page).toHaveURL("/matches");
+  });
+});

--- a/e2e/register.spec.ts
+++ b/e2e/register.spec.ts
@@ -1,15 +1,12 @@
 import { expect, type Page, test } from "@playwright/test";
-import {
-  fillDisplayId,
-  fillEmail,
-  fillName,
-  randomDisplayId,
-  randomEmail,
-} from "./helpers";
+import { fillInput, randomDisplayId, randomEmail } from "./helpers";
 
 async function createFreshSignedUpUser(page: Page) {
   await page.goto("/sign-up");
-  await fillEmail(page, randomEmail());
+  await fillInput(
+    page.getByRole("textbox", { name: "メールアドレス" }),
+    randomEmail(),
+  );
   await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
   await page.getByRole("button", { name: "新規登録", exact: true }).click();
   await page.waitForURL(/\/register/);
@@ -30,20 +27,23 @@ test.describe("ユーザー情報登録 - バリデーション", () => {
   test("ユーザーIDを入力せずに送信するとバリデーションエラー", async ({
     page,
   }) => {
-    await fillName(page.getByRole("textbox", { name: "名前" }), "テスト");
+    await fillInput(page.getByRole("textbox", { name: "名前" }), "テスト");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(page.getByText("ユーザーIDを入力してください")).toBeVisible();
   });
 
   test("名前を入力せずに送信するとバリデーションエラー", async ({ page }) => {
-    await fillDisplayId(page, randomDisplayId());
+    await fillInput(
+      page.getByRole("textbox", { name: "ユーザーID" }),
+      randomDisplayId(),
+    );
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(page.getByText("名前を入力してください")).toBeVisible();
   });
 
   test("ユーザーIDが短いとバリデーションエラー", async ({ page }) => {
-    await fillDisplayId(page, "abc");
-    await fillName(page.getByRole("textbox", { name: "名前" }), "テスト");
+    await fillInput(page.getByRole("textbox", { name: "ユーザーID" }), "abc");
+    await fillInput(page.getByRole("textbox", { name: "名前" }), "テスト");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(
       page.getByText("ユーザーIDは4文字以上で入力してください"),
@@ -51,8 +51,11 @@ test.describe("ユーザー情報登録 - バリデーション", () => {
   });
 
   test("ユーザーIDが長すぎるとバリデーションエラー", async ({ page }) => {
-    await fillDisplayId(page, "a".repeat(13));
-    await fillName(page.getByRole("textbox", { name: "名前" }), "テスト");
+    await fillInput(
+      page.getByRole("textbox", { name: "ユーザーID" }),
+      "a".repeat(13),
+    );
+    await fillInput(page.getByRole("textbox", { name: "名前" }), "テスト");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(
       page.getByText("ユーザーIDは12文字以内で入力してください"),
@@ -62,8 +65,11 @@ test.describe("ユーザー情報登録 - バリデーション", () => {
   test("ユーザーIDに半角英数字以外を含むとバリデーションエラー", async ({
     page,
   }) => {
-    await fillDisplayId(page, "ユーザー");
-    await fillName(page.getByRole("textbox", { name: "名前" }), "テスト");
+    await fillInput(
+      page.getByRole("textbox", { name: "ユーザーID" }),
+      "ユーザー",
+    );
+    await fillInput(page.getByRole("textbox", { name: "名前" }), "テスト");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(
       page.getByText("ユーザーIDは半角英数字のみで入力してください"),
@@ -71,15 +77,21 @@ test.describe("ユーザー情報登録 - バリデーション", () => {
   });
 
   test("すでに使われているユーザーIDを指定するとエラー", async ({ page }) => {
-    await fillDisplayId(page, "testuser");
-    await fillName(page.getByRole("textbox", { name: "名前" }), "別ユーザー");
+    await fillInput(
+      page.getByRole("textbox", { name: "ユーザーID" }),
+      "testuser",
+    );
+    await fillInput(page.getByRole("textbox", { name: "名前" }), "別ユーザー");
     await page.getByRole("button", { name: "決定", exact: true }).click();
     await expect(page.getByText("このIDは既に使用されています")).toBeVisible();
   });
 
   test("名前が長すぎるとバリデーションエラー", async ({ page }) => {
-    await fillDisplayId(page, randomDisplayId());
-    await fillName(
+    await fillInput(
+      page.getByRole("textbox", { name: "ユーザーID" }),
+      randomDisplayId(),
+    );
+    await fillInput(
       page.getByRole("textbox", { name: "名前" }),
       "あ".repeat(13),
     );
@@ -100,8 +112,14 @@ test.describe("ユーザー情報登録 - 副作用を伴うフロー", () => {
   test("正しい情報で登録すると /matches に遷移する", async ({ page }) => {
     await createFreshSignedUpUser(page);
 
-    await fillDisplayId(page, randomDisplayId());
-    await fillName(page.getByRole("textbox", { name: "名前" }), "新規ユーザー");
+    await fillInput(
+      page.getByRole("textbox", { name: "ユーザーID" }),
+      randomDisplayId(),
+    );
+    await fillInput(
+      page.getByRole("textbox", { name: "名前" }),
+      "新規ユーザー",
+    );
     await page.getByRole("button", { name: "決定", exact: true }).click();
 
     await expect(page).toHaveURL("/matches");

--- a/e2e/sign-up.spec.ts
+++ b/e2e/sign-up.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { randomEmail } from "./helpers";
+import { fillEmail, randomEmail } from "./helpers";
 
 test.describe("新規登録", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
@@ -9,9 +9,7 @@ test.describe("新規登録", () => {
   }) => {
     await page.goto("/sign-up");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill(randomEmail());
+    await fillEmail(page, randomEmail());
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 
@@ -23,9 +21,7 @@ test.describe("新規登録", () => {
   }) => {
     await page.goto("/sign-up");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill("test@example.com");
+    await fillEmail(page, "test@example.com");
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 
@@ -38,9 +34,7 @@ test.describe("新規登録", () => {
   test("メールアドレス形式が不正ならバリデーションエラー", async ({ page }) => {
     await page.goto("/sign-up");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill("not-an-email");
+    await fillEmail(page, "not-an-email");
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 
@@ -65,9 +59,7 @@ test.describe("新規登録", () => {
   test("パスワード未入力ならバリデーションエラー", async ({ page }) => {
     await page.goto("/sign-up");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill(randomEmail());
+    await fillEmail(page, randomEmail());
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 
     await expect(page.getByText("パスワードを入力してください")).toBeVisible();
@@ -77,9 +69,7 @@ test.describe("新規登録", () => {
   test("パスワードが短い場合はバリデーションエラー", async ({ page }) => {
     await page.goto("/sign-up");
 
-    await page
-      .getByRole("textbox", { name: "メールアドレス" })
-      .fill(randomEmail());
+    await fillEmail(page, randomEmail());
     await page.getByRole("textbox", { name: "パスワード" }).fill("12345");
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 

--- a/e2e/sign-up.spec.ts
+++ b/e2e/sign-up.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+import { randomEmail } from "./helpers";
+
+test.describe("新規登録", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("正しい情報で新規登録すると、登録ページへリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/sign-up");
+
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill(randomEmail());
+    await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+    await page.getByRole("button", { name: "新規登録", exact: true }).click();
+
+    await expect(page).toHaveURL(/\/register/);
+  });
+
+  test("すでに使用されているメールアドレスでは登録できない", async ({
+    page,
+  }) => {
+    await page.goto("/sign-up");
+
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill("test@example.com");
+    await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+    await page.getByRole("button", { name: "新規登録", exact: true }).click();
+
+    await expect(
+      page.getByText("このメールアドレスは使用できません"),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/sign-up");
+  });
+
+  test("メールアドレス形式が不正ならバリデーションエラー", async ({ page }) => {
+    await page.goto("/sign-up");
+
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill("not-an-email");
+    await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+    await page.getByRole("button", { name: "新規登録", exact: true }).click();
+
+    await expect(
+      page.getByText("メールアドレスを正しい形式で入力してください"),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/sign-up");
+  });
+
+  test("メールアドレス未入力ならバリデーションエラー", async ({ page }) => {
+    await page.goto("/sign-up");
+
+    await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+    await page.getByRole("button", { name: "新規登録", exact: true }).click();
+
+    await expect(
+      page.getByText("メールアドレスを入力してください"),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/sign-up");
+  });
+
+  test("パスワード未入力ならバリデーションエラー", async ({ page }) => {
+    await page.goto("/sign-up");
+
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill(randomEmail());
+    await page.getByRole("button", { name: "新規登録", exact: true }).click();
+
+    await expect(page.getByText("パスワードを入力してください")).toBeVisible();
+    await expect(page).toHaveURL("/sign-up");
+  });
+
+  test("パスワードが短い場合はバリデーションエラー", async ({ page }) => {
+    await page.goto("/sign-up");
+
+    await page
+      .getByRole("textbox", { name: "メールアドレス" })
+      .fill(randomEmail());
+    await page.getByRole("textbox", { name: "パスワード" }).fill("12345");
+    await page.getByRole("button", { name: "新規登録", exact: true }).click();
+
+    await expect(
+      page.getByText("パスワードは6文字以上で入力してください"),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/sign-up");
+  });
+
+  test("新規登録ページにログインへのリンクが存在する", async ({ page }) => {
+    await page.goto("/sign-up");
+    await expect(page.getByRole("link", { name: "ログイン" })).toBeVisible();
+  });
+});

--- a/e2e/sign-up.spec.ts
+++ b/e2e/sign-up.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { fillEmail, randomEmail } from "./helpers";
+import { fillInput, randomEmail } from "./helpers";
 
 test.describe("新規登録", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
@@ -9,7 +9,10 @@ test.describe("新規登録", () => {
   }) => {
     await page.goto("/sign-up");
 
-    await fillEmail(page, randomEmail());
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      randomEmail(),
+    );
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 
@@ -21,7 +24,10 @@ test.describe("新規登録", () => {
   }) => {
     await page.goto("/sign-up");
 
-    await fillEmail(page, "test@example.com");
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      "test@example.com",
+    );
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 
@@ -34,7 +40,10 @@ test.describe("新規登録", () => {
   test("メールアドレス形式が不正ならバリデーションエラー", async ({ page }) => {
     await page.goto("/sign-up");
 
-    await fillEmail(page, "not-an-email");
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      "not-an-email",
+    );
     await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 
@@ -59,7 +68,10 @@ test.describe("新規登録", () => {
   test("パスワード未入力ならバリデーションエラー", async ({ page }) => {
     await page.goto("/sign-up");
 
-    await fillEmail(page, randomEmail());
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      randomEmail(),
+    );
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 
     await expect(page.getByText("パスワードを入力してください")).toBeVisible();
@@ -69,7 +81,10 @@ test.describe("新規登録", () => {
   test("パスワードが短い場合はバリデーションエラー", async ({ page }) => {
     await page.goto("/sign-up");
 
-    await fillEmail(page, randomEmail());
+    await fillInput(
+      page.getByRole("textbox", { name: "メールアドレス" }),
+      randomEmail(),
+    );
     await page.getByRole("textbox", { name: "パスワード" }).fill("12345");
     await page.getByRole("button", { name: "新規登録", exact: true }).click();
 

--- a/e2e/unregistered.setup.ts
+++ b/e2e/unregistered.setup.ts
@@ -1,0 +1,22 @@
+import { test as setup } from "@playwright/test";
+
+/**
+ * 新規サインアップ直後・プロフィール未登録状態のユーザーのセッションを保存する。
+ * register.spec.ts のバリデーションテストで共有される。
+ */
+const authFile = "e2e/.auth/unregistered.json";
+
+setup("authenticate unregistered user", async ({ page }) => {
+  await page.goto("/login");
+
+  await page
+    .getByRole("textbox", { name: "メールアドレス" })
+    .fill("unregistered@example.com");
+  await page.getByRole("textbox", { name: "パスワード" }).fill("password123");
+  await page.getByRole("button", { name: "ログイン", exact: true }).click();
+
+  // 未登録ユーザーは /matches アクセス時にアバター表示ロジックで /register に飛ばされる
+  await page.waitForURL(/\/register/);
+
+  await page.context().storageState({ path: authFile });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
   webServer: {
     command: "npm run dev -- -p 3003",
     url: "http://localhost:3003",
-    reuseExistingServer: false,
+    reuseExistingServer: !process.env.CI,
     env: {
       NEXT_PUBLIC_SUPABASE_URL: SUPABASE_LOCAL_URL,
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: SUPABASE_LOCAL_PUBLISHABLE_KEY,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,20 +7,16 @@ const SUPABASE_LOCAL_PUBLISHABLE_KEY =
 export default defineConfig({
   globalSetup: "./e2e/global-setup.ts",
   testDir: "./e2e",
+  // global-setup で投入した Supabase の seed を全テストで共有しているため、
+  // 並列化すると同一レコードへの書き込みが競合する。よって 1 ワーカーで順次実行する。
   fullyParallel: false,
   workers: 1,
   reporter: [["html", { outputFolder: "e2e/playwright-report" }]],
   outputDir: "e2e/test-results",
 
-  expect: {
-    timeout: 10000,
-  },
-
   use: {
     baseURL: "http://localhost:3003",
     trace: "on-first-retry",
-    actionTimeout: 15000,
-    navigationTimeout: 30000,
   },
 
   projects: [
@@ -62,7 +58,6 @@ export default defineConfig({
   webServer: {
     command: "npm run dev -- -p 3003",
     url: "http://localhost:3003",
-    reuseExistingServer: !process.env.CI,
     env: {
       NEXT_PUBLIC_SUPABASE_URL: SUPABASE_LOCAL_URL,
       NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: SUPABASE_LOCAL_PUBLISHABLE_KEY,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,8 @@ const SUPABASE_LOCAL_PUBLISHABLE_KEY =
 
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: true,
+  fullyParallel: false,
+  workers: 1,
   reporter: [["html", { outputFolder: "e2e/playwright-report" }]],
   outputDir: "e2e/test-results",
 
@@ -22,11 +23,22 @@ export default defineConfig({
     },
     {
       name: "chromium",
+      // logout系はセッションを破壊するため cleanup プロジェクトで最後に実行する
+      testIgnore: /logout\.spec\.ts/,
       use: {
         ...devices["Desktop Chrome"],
         storageState: "e2e/.auth/user.json",
       },
       dependencies: ["setup"],
+    },
+    {
+      name: "cleanup",
+      testMatch: /logout\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "e2e/.auth/user.json",
+      },
+      dependencies: ["chromium"],
     },
   ],
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,15 +5,22 @@ const SUPABASE_LOCAL_PUBLISHABLE_KEY =
   "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH";
 
 export default defineConfig({
+  globalSetup: "./e2e/global-setup.ts",
   testDir: "./e2e",
   fullyParallel: false,
   workers: 1,
   reporter: [["html", { outputFolder: "e2e/playwright-report" }]],
   outputDir: "e2e/test-results",
 
+  expect: {
+    timeout: 10000,
+  },
+
   use: {
     baseURL: "http://localhost:3003",
     trace: "on-first-retry",
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
   },
 
   projects: [
@@ -32,13 +39,23 @@ export default defineConfig({
       dependencies: ["setup"],
     },
     {
+      name: "webkit",
+      // logout系はセッションを破壊するため cleanup プロジェクトで最後に実行する
+      testIgnore: /logout\.spec\.ts/,
+      use: {
+        ...devices["Desktop Safari"],
+        storageState: "e2e/.auth/user.json",
+      },
+      dependencies: ["setup"],
+    },
+    {
       name: "cleanup",
       testMatch: /logout\.spec\.ts/,
       use: {
         ...devices["Desktop Chrome"],
         storageState: "e2e/.auth/user.json",
       },
-      dependencies: ["chromium"],
+      dependencies: ["webkit"],
     },
   ],
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -175,3 +175,48 @@ INSERT INTO public.rules (
   10000, 0, 'round', '0_0_0_0',
   '11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111'
 );
+
+-- E2E用の事前マッチ（三麻・3人参加・ゲーム/チップ未入力）
+INSERT INTO public.matches (id, created_by, created_at) VALUES
+  (
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    '11111111-1111-1111-1111-111111111111',
+    now()
+  );
+
+INSERT INTO public.match_players (match_id, player_id, "order") VALUES
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', 0),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '22222222-2222-2222-2222-222222222222', 1),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '33333333-3333-3333-3333-333333333333', 2);
+
+INSERT INTO public.rules (
+  match_id, players_count, rate, default_points, default_calc_points,
+  crack_box_bonus, chip_rate, calc_method, incline, created_by, updated_by
+) VALUES (
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 3, 0, 35000, 40000,
+  10000, 0, 'round', '0_0_0',
+  '11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111'
+);
+
+-- E2E用の事前マッチ（三麻ルール・4人参加=ルール人数超過・ゲーム/チップ未入力）
+INSERT INTO public.matches (id, created_by, created_at) VALUES
+  (
+    'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    '11111111-1111-1111-1111-111111111111',
+    now()
+  );
+
+INSERT INTO public.match_players (match_id, player_id, "order") VALUES
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '11111111-1111-1111-1111-111111111111', 0),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '22222222-2222-2222-2222-222222222222', 1),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '33333333-3333-3333-3333-333333333333', 2),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '44444444-4444-4444-4444-444444444444', 3);
+
+INSERT INTO public.rules (
+  match_id, players_count, rate, default_points, default_calc_points,
+  crack_box_bonus, chip_rate, calc_method, incline, created_by, updated_by
+) VALUES (
+  'cccccccc-cccc-cccc-cccc-cccccccccccc', 3, 0, 35000, 40000,
+  10000, 0, 'round', '0_0_0',
+  '11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111'
+);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -10,10 +10,10 @@ INSERT INTO auth.users (
   created_at, updated_at,
   confirmation_token, recovery_token,
   email_change, email_change_token_new, email_change_token_current,
-  phone, phone_change, phone_change_token,
   reauthentication_token,
   is_sso_user, is_anonymous
-) VALUES (
+) VALUES
+(
   '00000000-0000-0000-0000-000000000000',
   '11111111-1111-1111-1111-111111111111',
   'authenticated', 'authenticated',
@@ -25,6 +25,66 @@ INSERT INTO auth.users (
   now(), now(),
   '', '',
   '', '', '',
+  '',
+  false, false
+),
+(
+  '00000000-0000-0000-0000-000000000000',
+  '22222222-2222-2222-2222-222222222222',
+  'authenticated', 'authenticated',
+  'alice@example.com',
+  crypt('password123', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}',
+  '{}',
+  now(), now(),
+  '', '',
+  '', '', '',
+  '',
+  false, false
+),
+(
+  '00000000-0000-0000-0000-000000000000',
+  '33333333-3333-3333-3333-333333333333',
+  'authenticated', 'authenticated',
+  'bob@example.com',
+  crypt('password123', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}',
+  '{}',
+  now(), now(),
+  '', '',
+  '', '', '',
+  '',
+  false, false
+),
+(
+  '00000000-0000-0000-0000-000000000000',
+  '44444444-4444-4444-4444-444444444444',
+  'authenticated', 'authenticated',
+  'carol@example.com',
+  crypt('password123', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}',
+  '{}',
+  now(), now(),
+  '', '',
+  '', '', '',
+  '',
+  false, false
+),
+-- 新規サインアップ直後の想定（display_id, name は NULL のまま）
+(
+  '00000000-0000-0000-0000-000000000000',
+  '55555555-5555-5555-5555-555555555555',
+  'authenticated', 'authenticated',
+  'unregistered@example.com',
+  crypt('password123', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}',
+  '{}',
+  now(), now(),
+  '', '',
   '', '', '',
   '',
   false, false
@@ -33,16 +93,85 @@ INSERT INTO auth.users (
 INSERT INTO auth.identities (
   id, user_id, identity_data, provider, provider_id,
   last_sign_in_at, created_at, updated_at
-) VALUES (
+) VALUES
+(
   gen_random_uuid(),
   '11111111-1111-1111-1111-111111111111',
   jsonb_build_object('sub', '11111111-1111-1111-1111-111111111111', 'email', 'test@example.com'),
   'email',
   '11111111-1111-1111-1111-111111111111',
   now(), now(), now()
+),
+(
+  gen_random_uuid(),
+  '22222222-2222-2222-2222-222222222222',
+  jsonb_build_object('sub', '22222222-2222-2222-2222-222222222222', 'email', 'alice@example.com'),
+  'email',
+  '22222222-2222-2222-2222-222222222222',
+  now(), now(), now()
+),
+(
+  gen_random_uuid(),
+  '33333333-3333-3333-3333-333333333333',
+  jsonb_build_object('sub', '33333333-3333-3333-3333-333333333333', 'email', 'bob@example.com'),
+  'email',
+  '33333333-3333-3333-3333-333333333333',
+  now(), now(), now()
+),
+(
+  gen_random_uuid(),
+  '44444444-4444-4444-4444-444444444444',
+  jsonb_build_object('sub', '44444444-4444-4444-4444-444444444444', 'email', 'carol@example.com'),
+  'email',
+  '44444444-4444-4444-4444-444444444444',
+  now(), now(), now()
+),
+(
+  gen_random_uuid(),
+  '55555555-5555-5555-5555-555555555555',
+  jsonb_build_object('sub', '55555555-5555-5555-5555-555555555555', 'email', 'unregistered@example.com'),
+  'email',
+  '55555555-5555-5555-5555-555555555555',
+  now(), now(), now()
 );
 
 -- handle_new_user トリガーにより自動作成されたプロフィールを更新
-UPDATE public.profiles
-SET display_id = 'testuser', name = 'テストユーザー'
+UPDATE public.profiles SET display_id = 'testuser', name = 'テストユーザー'
 WHERE id = '11111111-1111-1111-1111-111111111111';
+UPDATE public.profiles SET display_id = 'alice123', name = 'アリス'
+WHERE id = '22222222-2222-2222-2222-222222222222';
+UPDATE public.profiles SET display_id = 'bob123', name = 'ボブ'
+WHERE id = '33333333-3333-3333-3333-333333333333';
+UPDATE public.profiles SET display_id = 'carol123', name = 'キャロル'
+WHERE id = '44444444-4444-4444-4444-444444444444';
+
+-- testuser のフレンドとして alice, bob, carol を登録
+-- （検索不要でデフォルトフレンド一覧から選択できるようにするため）
+INSERT INTO public.friends (profile_id, friend_id) VALUES
+  ('11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222'),
+  ('11111111-1111-1111-1111-111111111111', '33333333-3333-3333-3333-333333333333'),
+  ('11111111-1111-1111-1111-111111111111', '44444444-4444-4444-4444-444444444444');
+
+-- E2E用の事前マッチ（四麻・4人参加・ゲーム/チップ未入力）
+-- match-detail.spec.ts から直接この id に遷移して使う
+INSERT INTO public.matches (id, created_by, created_at) VALUES
+  (
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    '11111111-1111-1111-1111-111111111111',
+    now()
+  );
+
+INSERT INTO public.match_players (match_id, player_id, "order") VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 0),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 1),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '33333333-3333-3333-3333-333333333333', 2),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '44444444-4444-4444-4444-444444444444', 3);
+
+INSERT INTO public.rules (
+  match_id, players_count, rate, default_points, default_calc_points,
+  crack_box_bonus, chip_rate, calc_method, incline, created_by, updated_by
+) VALUES (
+  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 4, 0, 25000, 30000,
+  10000, 0, 'round', '0_0_0_0',
+  '11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111'
+);


### PR DESCRIPTION
## 概要

E2Eテストが不足していたため、フォームバリデーションを中心に各種フローを網羅するテストを追加しました。合わせて実行時間を抑えるために seed データと storageState を活用し、テスト挙動を壊さない範囲でテスト容易性を高める小変更を UI 側にも入れています。

## 変更内容

### 追加したテスト（9ファイル / 合計77テスト）

- `e2e/sign-up.spec.ts` — 新規登録のバリデーション網羅
- `e2e/register.spec.ts` — ユーザー情報登録。バリデーションは未登録ユーザーの storageState を使い回し、書き込みを伴うフローのみ毎回新規サインアップ
- `e2e/profile.spec.ts` — プロフィール編集のバリデーション / 保存トースト
- `e2e/friends.spec.ts` — フレンド検索・追加・削除
- `e2e/matches.spec.ts` — 成績表一覧・ドロワー開閉
- `e2e/create-match.spec.ts` — 作成ドロワーのルール設定（四麻/三麻切替・ウマ/チップカスタム・詳細設定）とプレイヤー選択〜完了フロー
- `e2e/match-detail.spec.ts` — seedで用意した既存マッチに直接遷移し、ヘッダー / ゲーム結果入力 / チップ入力の各挙動を検証
- `e2e/logout.spec.ts` — ログアウト（cleanup プロジェクトで最後に実行）
- `e2e/auth.spec.ts` — 既存ログインテストに各種バリデーションと未認証リダイレクトを追加

### 共通ヘルパー・テスト用セットアップ

- `e2e/helpers.ts` — テストユーザー定数（`TEST_USERS`）、seed match の ID/URL、`randomEmail`/`randomDisplayId`、`loginAs`
- `e2e/unregistered.setup.ts` — 未登録ユーザー（`unregistered@example.com`）の session を `e2e/.auth/unregistered.json` に保存

### seed 追加

- `supabase/seed.sql`:
  - `alice / bob / carol`（登録済み・testuser のフレンド）と `unregistered`（未登録）ユーザーを追加
  - testuser と alice/bob/carol のフレンド関係を登録（作成ドロワーで検索せずに選択できるようにするため）
  - 4人参加・ゲーム/チップ未登録の seed match（固定UUID）を追加

### UI の小変更（テスト容易性のため、見た目に影響なし）

テスト側から `getByRole` で一意に選択できるよう、アイコン only のボタン/リンクに `aria-label` を付与:

- `app/(main)/_components/appbar/appbar-avatar` → `プロフィールメニュー`
- `app/(main)/friends/_components/friend-menu` → `フレンドメニュー`
- `app/(main)/friends/_components/add-button` → `フレンド追加`
- `app/(main)/friends/add/_components/back-button` → `戻る`
- `app/(main)/matches/[matchId]/_components/match-header` → `戻る` / `ルールを確認` / `プレイヤーを追加`

### Playwright 設定の整理

- `fullyParallel: false`, `workers: 1` に明示（テスト間の DB/セッション状態共有を前提とした直列実行）
- `cleanup` プロジェクトを追加し、session を破壊する `logout.spec.ts` を `chromium` プロジェクト完了後に走らせる構成に変更。ファイル名の `zz-` プレフィックス依存を廃止

## 実行結果

ローカルで `npx supabase start && npx supabase db reset && npm run test:e2e` を実行:

- **77 passed / 約 1 分 6 秒**

Made with [Cursor](https://cursor.com)