### PR TITLE
Renovateのパッケージグループを拡張

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,23 @@
     {
       "groupName": "conform-to",
       "matchPackageNames": ["@conform-to/react", "@conform-to/zod"]
+    },
+    {
+      "groupName": "heroui",
+      "matchPackageNames": ["@heroui/react", "@heroui/styles"]
+    },
+    {
+      "groupName": "react",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ]
+    },
+    {
+      "groupName": "typescript-eslint",
+      "matchPackageNames": ["@typescript-eslint/parser", "typescript-eslint"]
     }
   ]
 }


### PR DESCRIPTION
## 概要

Renovate の `packageRules` に関連パッケージのグループを追加し、依存関係の更新 PR をまとめてレビューしやすくします。

## 変更内容

- HeroUI（`@heroui/react` / `@heroui/styles`）を同一グループで更新
- React 系（`react` / `react-dom` / `@types/react` / `@types/react-dom`）を同一グループで更新
- TypeScript ESLint 系（`@typescript-eslint/parser` / `typescript-eslint`）を同一グループで更新

## 補足

既存の `@conform-to/*` グループ設定に続けて追加しています。