### PR TITLE
Supabase維持ワークフローのpingエンドポイントを修正

### DIFF
--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -20,6 +20,7 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: |
-            curl -X GET "$SUPABASE_URL/rest/v1/profiles?select=*&limit=1" \
+            curl -X GET "$SUPABASE_URL/rest/v1/" \
             -H "apikey: $SUPABASE_ANON_KEY" \
-            -H "Authorization: Bearer $SUPABASE_ANON_KEY"
+            -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+            --fail


### PR DESCRIPTION
## 概要

Supabase 無料プランの非アクティブによる停止を防ぐため、pingエンドポイントをより確実にDBへアクセスするものに変更。

## 変更内容

- `/rest/v1/profiles?select=*&limit=1` → `/rest/v1/` に変更
  - profiles テーブルが空の場合、PostgREST がDBに実際に接続せずキャッシュ的に処理していた可能性があった
  - `/rest/v1/` は OpenAPI スキーマを返すエンドポイントで、DBスキーマのイントロスペクションが必須なため、必ず実際のDB接続が発生する
- `--fail` フラグを追加
  - HTTP エラー時に curl が exit 1 を返すようになり、プロジェクトが停止していても GitHub Actions が失敗として検知できる