### PR TITLE
Supabase pingエンドポイントを /rest/v1/profiles に戻す

### DIFF
--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -20,7 +20,7 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: |
-            curl -X GET "$SUPABASE_URL/rest/v1/" \
+            curl -X GET "$SUPABASE_URL/rest/v1/profiles?select=*&limit=1" \
             -H "apikey: $SUPABASE_ANON_KEY" \
             -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
             --fail


### PR DESCRIPTION
## 概要

`/rest/v1/` (OpenAPI エンドポイント) への変更を差し戻す。

## 原因

`/rest/v1/` は PostgREST が OpenAPI スキーマ生成のために `information_schema` をクエリするが、anon ロールは `information_schema` にアクセスできないため 401 が返っていた。

## 変更内容

- `/rest/v1/` → `/rest/v1/profiles?select=*&limit=1` に戻す
- `--fail` は維持（HTTP エラーを GitHub Actions の失敗として検知するため）