### PR TITLE
スキーマの点数（points）transform の真偽判定を簡素化

### DIFF
--- a/lib/utils/schema.ts
+++ b/lib/utils/schema.ts
@@ -76,7 +76,7 @@ export const schema = {
   playersCount: z.union([z.literal("4"), z.literal("3")]).transform(Number),
   points: z
     .string("点数を入力してください")
-    .transform((v) => (v === "0" || !!v ? Number(v) * 100 : undefined)),
+    .transform((v) => (v === "0" || v ? Number(v) * 100 : undefined)),
   rate: z.string().transform(Number),
   inclineFor4Players: z
     .object({


### PR DESCRIPTION
## 概要

`lib/utils/schema.ts` の `points` フィールドにおいて、transform 内の空入力判定に使っていた `!!v` を `v` に置き換え、不要な二重否定をやめて読みやすくしました。`z.string()` の入力に対しては、`""` を除く通常の文字列では従来と同様に数値変換が行われます。

## 変更内容

- `points` の transform 条件を `v === "0" || !!v` から `v === "0" || v` に変更

## レビュー観点

- 点数入力が空・`"0"`・その他の数値文字列のときの期待どおりの変換か

---

**提案ラベル**: `refactor` または `chore`（コードスタイル・軽微な整理の場合）
