### PR TITLE
game入力submit後に「飛ばした人」selectがリセットされない問題の修正

### DIFF
--- a/app/(main)/matches/[matchId]/_components/create-game-drawer/actions.ts
+++ b/app/(main)/matches/[matchId]/_components/create-game-drawer/actions.ts
@@ -46,5 +46,5 @@ export async function createGame(
 
   revalidatePath(`/matches/${matchId}`);
 
-  return report(submission, {});
+  return report(submission, { reset: true });
 }

--- a/app/(main)/matches/[matchId]/_components/create-game-drawer/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/create-game-drawer/index.tsx
@@ -37,7 +37,7 @@ export function CreateGameDrawer({
   const { rule } = match;
   const [lastResult, formAction, isPending] = useActionState(
     withCallbacks(createGame.bind(null, match.id, rule), {
-      onSuccess: () => onOpenChange(false),
+      onSuccess: () => handleOpenChange(false),
     }),
     null,
   );


### PR DESCRIPTION
## 概要

game入力フォームのsubmit成功後、「飛ばした人」のselectが前回の選択値を保持したままになる問題を修正しました。

## 原因

`withCallbacks` の `onSuccess` コールバックは server action の解決中に同期的に呼ばれますが、`useActionState` が `lastResult` を更新するのはその後になります。そのため以下の順序で問題が発生していました。

1. `onSuccess` → `handleOpenChange(false)` → `intent.reset()` でselectのkeyが変わりリセット
2. `lastResult` が `report(submission, {})` の値（= submitされたpayloadを含む）で更新
3. conformが新しい `lastResult` をもとにフォーム状態を再計算し、selectが前の選択値に戻る

## 変更内容

- `actions.ts`: `report(submission, {})` → `report(submission, { reset: true })` に変更
  - conformの `SubmissionResult` の `reset` フラグを利用し、server actionの返り値でフォームを完全リセットさせる
- `index.tsx`: `onSuccess` 内で `onOpenChange(false)` → `handleOpenChange(false)` に変更
  - `handleOpenChange` 経由でドロワーを閉じることで `intent.reset()` が正しく呼ばれるようにする