### PR TITLE
Rechartsレイアウト修正・プレイヤー選択のa11y改善・LP/ルートの細かい調整

### DIFF
--- a/app/(lp)/page.tsx
+++ b/app/(lp)/page.tsx
@@ -176,6 +176,7 @@ export default function LandingPage() {
               alt="アプリのインターフェース"
               sizes="80vw"
               className="size-full object-cover object-top"
+              preload
             />
           </div>
         </div>

--- a/app/(main)/matches/[matchId]/_components/data-chart/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/data-chart/index.tsx
@@ -50,7 +50,12 @@ export function DataChart({
 
   return (
     <Surface className={cn("h-[300px] rounded-3xl p-2", className)}>
-      <ResponsiveContainer width="100%" height="100%">
+      <ResponsiveContainer
+        width="100%"
+        height="100%"
+        // https://github.com/recharts/recharts/issues/6716
+        initialDimension={{ width: 800, height: 300 }}
+      >
         <LineChart data={data}>
           <XAxis
             type="number"

--- a/app/(main)/matches/_components/player-selector/create-player-modal/index.tsx
+++ b/app/(main)/matches/_components/player-selector/create-player-modal/index.tsx
@@ -57,6 +57,7 @@ export function CreatePlayerModal({
                 variant="secondary"
                 name={fields.name.name}
                 maxLength={NAME_MAX_LENGTH}
+                aria-label="プレイヤー名"
               >
                 <Input placeholder="プレイヤー名を入力" />
                 <Description>{`${NAME_MAX_LENGTH}文字以内で入力してください`}</Description>

--- a/app/(main)/matches/_components/player-selector/index.tsx
+++ b/app/(main)/matches/_components/player-selector/index.tsx
@@ -25,7 +25,7 @@ function PlayerListBoxItem({
   isSelected: boolean;
 }) {
   return (
-    <ListBox.Item id={player.id}>
+    <ListBox.Item id={player.id} textValue={player.name ?? ""}>
       <UserAvatar avatarUrl={player.avatarUrl} name={player.name} size="sm" />
       <div className="flex flex-col">
         <div className="flex items-center gap-1">
@@ -153,6 +153,7 @@ export function PlayerSelector({
         variant="secondary"
         className="mx-1 mt-4 mb-1"
         onChange={handleSearch}
+        aria-label="検索"
       >
         <SearchField.Group>
           <SearchField.SearchIcon />
@@ -166,7 +167,11 @@ export function PlayerSelector({
           onAction={(key) => handleListBoxAction(key, friends)}
           className="px-0"
         >
-          <ListBox.Item id="new" className="flex w-full items-center">
+          <ListBox.Item
+            id="new"
+            className="flex w-full items-center"
+            aria-label="新規プレイヤー作成"
+          >
             <Avatar size="sm" variant="soft" color="accent">
               <Avatar.Fallback>
                 <PlusIcon />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,6 +31,7 @@ export default function RootLayout({
     <html
       lang="ja"
       className={cn(fontClassNames, "scroll-smooth")}
+      data-scroll-behavior="smooth"
       suppressHydrationWarning
     >
       <body className="bg-background font-rocknroll text-foreground">


### PR DESCRIPTION
## 概要

対局詳細の折れ線グラフで発生しうる Recharts の初期寸法まわりの問題への対処、プレイヤー選択 UI のアクセシビリティ強化、ランディングページのヒーロー画像の読み込み、およびルートレイアウトのスクロール挙動の明示を行います。

## 変更内容

- `DataChart` の `ResponsiveContainer` に `initialDimension` を指定（[recharts#6716](https://github.com/recharts/recharts/issues/6716) 系の挙動への回避）
- プレイヤー選択: `ListBox.Item` に `textValue`、検索・新規作成・名前入力まわりに `aria-label` を追加
- LP のヒーロー `Image` に `preload` を付与
- ルートの `<html>` に `data-scroll-behavior="smooth"` を追加（`scroll-smooth` クラスと併せた明示）