### PR TITLE
READMEにClaude Codeのエージェント設定ガイドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,67 @@ playwright.config.ts  # Playwright設定
 - `auth.setup.ts` がテスト用ユーザーでログインし、セッション情報を保存します
 - 各テストは保存されたセッションを再利用するため、毎回ログインする必要がありません
 
+# AI エージェント設定（Claude Code）
+
+## Skills
+
+Skills は Claude Code に専門的な知識や手順を教える仕組みです。`SKILL.md` ファイルとして管理されます。
+
+### 確認
+
+```shell
+# インストール済みスキルの一覧
+npx skills list
+
+# Claude Code セッション内で確認
+/skills
+```
+
+### 追加
+
+```shell
+npx skills add <owner/repo>
+
+# 例
+npx skills add supabase/agent-skills
+```
+
+実行すると `.claude/skills/` にファイルが配置され、`skills-lock.json` が更新されます。`skills-lock.json` は git にコミットしてください。
+
+### 適用
+
+Claude Code は `.claude/skills/` 配下の SKILL.md を自動検出します。追加の設定は不要です。
+
+## MCP サーバー
+
+MCP（Model Context Protocol）サーバーは Claude Code に外部ツール連携（DB操作、API呼び出し等）を提供します。
+
+### 確認
+
+```shell
+# ターミナルから
+claude mcp list
+
+# Claude Code セッション内で確認
+/mcp
+```
+
+### 追加
+
+```shell
+# HTTP/SSE サーバー
+claude mcp add <name> --transport http --url <url>
+
+# ローカルプロセス（stdio）
+claude mcp add <name> --transport stdio -- <command> [args...]
+```
+
+プロジェクト固有の MCP 設定は `.mcp.json` に保存されます。このファイルは git にコミットしてください。秘密情報はファイルに直書きせず、環境変数を使用してください。
+
+### 適用
+
+Claude Code 起動時に `.mcp.json` が自動で読み込まれます。追加の設定は不要です。
+
 # リンク
 
 - [supabase](https://supabase.com/docs)


### PR DESCRIPTION
## 概要

READMEにClaude CodeのSkillsとMCPサーバーの管理方法を追加しました。

## 変更内容

- Skills の確認・追加・適用方法を記載（`npx skills` CLI、`/skills` コマンド）
- MCP サーバーの確認・追加・適用方法を記載（`claude mcp` CLI、`/mcp` コマンド）
- `skills-lock.json` と `.mcp.json` の git 管理に関する説明を追加


Made with [Cursor](https://cursor.com)