### PR TITLE
テキスト要素をHeroUI Textコンポーネントに置き換え

### DIFF
--- a/app/(auth)/auth-code-error/page.tsx
+++ b/app/(auth)/auth-code-error/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@heroui/react";
+import { cn, Text } from "@heroui/react";
 import NextLink from "next/link";
 import { buttonVariants } from "@/components/button";
 
@@ -10,7 +10,7 @@ import { buttonVariants } from "@/components/button";
 export default function AuthCodeErrorPage() {
   return (
     <div className="flex flex-col items-center">
-      <h1>ログインに失敗しました</h1>
+      <Text type="h1">ログインに失敗しました</Text>
       <NextLink className={cn(buttonVariants(), "mt-4")} href="/login">
         ログイン画面へ戻る
       </NextLink>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,4 +1,4 @@
-import { linkVariants, Separator } from "@heroui/react";
+import { linkVariants, Separator, Text } from "@heroui/react";
 import type { Metadata } from "next";
 import NextLink from "next/link";
 import { LoginForm } from "./_components/login-form";
@@ -11,7 +11,9 @@ export const metadata: Metadata = {
 export default function LoginPage() {
   return (
     <div className="mx-auto max-w-md">
-      <h1 className="mx-auto mb-4 w-fit text-lg">ログイン</h1>
+      <Text type="h1" className="mx-auto mb-4 w-fit text-lg">
+        ログイン
+      </Text>
       <SocialProviders />
       <div className="my-4 flex items-center gap-4">
         <Separator className="shrink" />
@@ -19,12 +21,12 @@ export default function LoginPage() {
         <Separator className="shrink" />
       </div>
       <LoginForm />
-      <p className="mt-4 text-center text-sm">
+      <Text type="body-sm" align="center" className="mt-4">
         アカウントをお持ちでない方は
         <NextLink className={linkVariants().base()} href="/sign-up">
           新規登録
         </NextLink>
-      </p>
+      </Text>
     </div>
   );
 }

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,4 +1,4 @@
-import { linkVariants } from "@heroui/react";
+import { linkVariants, Text } from "@heroui/react";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { serverServices } from "@/lib/services/server";
@@ -19,12 +19,14 @@ export default async function RegisterPage() {
 
   return (
     <div className="mx-auto max-w-md">
-      <h1 className="mx-auto mb-4 w-fit text-lg">ユーザー情報登録</h1>
-      <p className="mb-6 text-sm text-muted">
+      <Text type="h1" className="mx-auto mb-4 w-fit text-lg">
+        ユーザー情報登録
+      </Text>
+      <Text type="body-sm" color="muted" className="mb-6">
         ユーザーIDと名前を決めてください。
         <br />
         ユーザーIDはユーザー検索に、名前は成績表に使用されます。
-      </p>
+      </Text>
       <RegisterForm userId={user.id} />
       <div className="mt-10 flex justify-center">
         <button

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,4 +1,4 @@
-import { linkVariants } from "@heroui/react";
+import { linkVariants, Text } from "@heroui/react";
 import type { Metadata } from "next";
 import NextLink from "next/link";
 import { SignUpForm } from "./_components/sign-up-form";
@@ -10,14 +10,16 @@ export const metadata: Metadata = {
 export default function SignUpPage() {
   return (
     <div className="mx-auto max-w-md">
-      <h1 className="mx-auto mb-2 w-fit text-lg">新規登録</h1>
+      <Text type="h1" className="mx-auto mb-2 w-fit text-lg">
+        新規登録
+      </Text>
       <SignUpForm />
-      <p className="text-center text-sm">
+      <Text type="body-sm" align="center">
         既にアカウントをお持ちの方は
         <NextLink className={linkVariants().base()} href="/login">
           ログイン
         </NextLink>
-      </p>
+      </Text>
     </div>
   );
 }

--- a/app/(lp)/page.tsx
+++ b/app/(lp)/page.tsx
@@ -1,4 +1,4 @@
-import { Card } from "@heroui/react";
+import { Card, Text } from "@heroui/react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Logo from "@/components/logo";
@@ -164,11 +164,11 @@ export default function LandingPage() {
       {/* ヒーローセクション */}
       <section className="bg-linear-to-b from-background to-accent/10">
         <div className="z-20 container mx-auto px-4 pt-20">
-          <p className="mb-8 text-center text-lg">
+          <Text align="center" className="mb-8 text-lg">
             麻雀の成績を簡単に記録・分析
             <br />
             あなたの麻雀ライフを快適に
-          </p>
+          </Text>
           <HeroCtaLinks />
           <div className="mx-auto mt-12 h-[480px] w-4/5 max-w-[500px]">
             <Image
@@ -185,7 +185,9 @@ export default function LandingPage() {
       <div className="container mx-auto space-y-24 px-5 py-16">
         {/* 機能紹介 */}
         <section id="features" className="">
-          <h2 className="mb-12 text-center text-lg">主な機能</h2>
+          <Text type="h2" align="center" className="mb-12 text-lg">
+            主な機能
+          </Text>
           <div
             className="
               grid grid-cols-1 gap-8
@@ -207,7 +209,9 @@ export default function LandingPage() {
         {/* 使用方法 */}
         <section className="">
           <div className="container mx-auto">
-            <h2 className="mb-12 text-center text-lg">使い方</h2>
+            <Text type="h2" align="center" className="mb-12 text-lg">
+              使い方
+            </Text>
             <div
               className="
                 grid grid-cols-1 gap-8
@@ -225,8 +229,10 @@ export default function LandingPage() {
                   >
                     {step.number}
                   </div>
-                  <h3 className="mb-2 text-base">{step.title}</h3>
-                  <p>{step.description}</p>
+                  <Text type="h3" className="mb-2 text-base">
+                    {step.title}
+                  </Text>
+                  <Text>{step.description}</Text>
                 </div>
               ))}
             </div>
@@ -236,7 +242,9 @@ export default function LandingPage() {
         {/* FAQ */}
         <section className="">
           <div className="container mx-auto">
-            <h2 className="mb-12 text-center text-lg">よくある質問</h2>
+            <Text type="h2" align="center" className="mb-12 text-lg">
+              よくある質問
+            </Text>
             <Faq faqs={faqs} />
           </div>
         </section>
@@ -244,7 +252,7 @@ export default function LandingPage() {
 
       {/* フッター */}
       <footer className="bg-accent py-8 text-center text-accent-foreground">
-        <p>&copy; 2024 Jankiroku. All rights reserved.</p>
+        <Text>&copy; 2024 Jankiroku. All rights reserved.</Text>
       </footer>
     </div>
   );

--- a/app/(main)/_components/appbar/appbar-avatar/index.tsx
+++ b/app/(main)/_components/appbar/appbar-avatar/index.tsx
@@ -1,4 +1,4 @@
-import { Dropdown } from "@heroui/react";
+import { Dropdown, Text } from "@heroui/react";
 import { redirect } from "next/navigation";
 import { UserAvatar } from "@/components/user-avatar";
 import { serverServices } from "@/lib/services/server";
@@ -33,10 +33,12 @@ export async function AppbarAvatar() {
           <div className="flex items-center gap-2">
             <UserAvatar avatarUrl={profile.avatarUrl} name={profile.name} />
             <div className="flex flex-col gap-0">
-              <p className="text-sm/5 font-medium">{profile.name}</p>
-              <p className="text-xs leading-none text-muted">
+              <Text type="body-sm" className="leading-5 font-medium">
+                {profile.name}
+              </Text>
+              <Text type="body-xs" color="muted" className="leading-none">
                 @{profile.displayId}
-              </p>
+              </Text>
             </div>
           </div>
         </div>

--- a/app/(main)/_components/release-notes/release-notes-modal/versions/0_1_0.tsx
+++ b/app/(main)/_components/release-notes/release-notes-modal/versions/0_1_0.tsx
@@ -1,13 +1,14 @@
+import { Text } from "@heroui/react";
 import { SERVICE_NAME } from "@/lib/config";
 
 export default function ReleaseNotes_0_1_0() {
   return (
     <>
-      <p>{SERVICE_NAME}へようこそ！</p>
-      <p>
+      <Text>{SERVICE_NAME}へようこそ！</Text>
+      <Text>
         現在はベータ版ですが、機能の追加や改善を行っていく予定です。今後のアップデートにご期待ください！
-      </p>
-      <h2>- 今後の機能追加予定 -</h2>
+      </Text>
+      <Text type="h2">- 今後の機能追加予定 -</Text>
       <ol className="list-inside list-disc">
         <li>半荘結果編集</li>
         <li>ユーザー情報編集</li>

--- a/app/(main)/_components/release-notes/release-notes-modal/versions/0_1_1.tsx
+++ b/app/(main)/_components/release-notes/release-notes-modal/versions/0_1_1.tsx
@@ -1,7 +1,9 @@
+import { Text } from "@heroui/react";
+
 export default function ReleaseNotes_0_1_0() {
   return (
     <>
-      <h2>Version 0.1.1</h2>
+      <Text type="h2">Version 0.1.1</Text>
       <ol className="list-inside list-disc">
         <li>ゲーム結果削除機能追加</li>
         <li>ゲーム入力において一部端末で画面が拡大してしまう問題の修正</li>

--- a/app/(main)/friends/add/page.tsx
+++ b/app/(main)/friends/add/page.tsx
@@ -1,3 +1,4 @@
+import { Text } from "@heroui/react";
 import { Suspense } from "react";
 import { User } from "@/components/user";
 import { serverServices } from "@/lib/services/server";
@@ -19,16 +20,18 @@ export default async function AddFriendPage({
     <div>
       <div className="mb-4 flex items-center gap-1">
         <BackButton />
-        <h1 className="heading-1">フレンド追加</h1>
+        <Text type="h1" className="heading-1">
+          フレンド追加
+        </Text>
       </div>
       <Suspense>
         <FriendSearch defaultValue={query ?? ""} />
       </Suspense>
       <ul className="mt-1">
         {!!query && profiles.length === 0 && (
-          <p className="mt-10 text-center text-sm text-muted">
+          <Text type="body-sm" color="muted" align="center" className="mt-10">
             見つかりませんでした
-          </p>
+          </Text>
         )}
         {profiles.map(({ id, name, displayId, avatarUrl, isFriend }) => (
           <li key={id} className="flex items-center justify-between py-2">

--- a/app/(main)/friends/loading.tsx
+++ b/app/(main)/friends/loading.tsx
@@ -1,10 +1,13 @@
+import { Text } from "@heroui/react";
 import { UserSkeleton } from "@/components/user";
 
 export default function FriendsLoading() {
   return (
     <div>
       <div className="mb-4 flex h-10 items-center justify-between">
-        <h1 className="heading-1">フレンド</h1>
+        <Text type="h1" className="heading-1">
+          フレンド
+        </Text>
       </div>
       <ul className="space-y-1">
         {Array.from({ length: 3 }, (_, i) => `skeleton-${i}`).map((id) => (

--- a/app/(main)/friends/page.tsx
+++ b/app/(main)/friends/page.tsx
@@ -1,3 +1,4 @@
+import { Text } from "@heroui/react";
 import { User } from "@/components/user";
 import { serverServices } from "@/lib/services/server";
 import { AddButton } from "./_components/add-button";
@@ -11,7 +12,9 @@ export default async function FriendsPage() {
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="heading-1">フレンド</h1>
+        <Text type="h1" className="heading-1">
+          フレンド
+        </Text>
         <AddButton />
       </div>
       <ul className="space-y-1">

--- a/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
@@ -6,6 +6,7 @@ import {
   FieldError,
   InputGroup,
   Label,
+  Text,
   TextField,
 } from "@heroui/react";
 import { useActionState } from "react";
@@ -125,9 +126,9 @@ export function ChipForm({
           })}
         </ul>
         {form.errors && (
-          <p className="text-xs whitespace-pre-wrap text-danger">
+          <Text type="body-xs" className="whitespace-pre-wrap text-danger">
             {form.errors}
-          </p>
+          </Text>
         )}
       </Drawer.Body>
       <Drawer.Footer>

--- a/app/(main)/matches/[matchId]/_components/create-game-drawer/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/create-game-drawer/index.tsx
@@ -11,6 +11,7 @@ import {
   ListBox,
   Select,
   Separator,
+  Text,
   TextField,
 } from "@heroui/react";
 import { ChevronDown, ChevronUp } from "lucide-react";
@@ -226,9 +227,12 @@ export function CreateGameDrawer({
                   })}
                 </ul>
                 {form.fieldErrors?.players?.[0] && (
-                  <p className="mt-1 text-xs whitespace-pre-wrap text-danger">
+                  <Text
+                    type="body-xs"
+                    className="mt-1 whitespace-pre-wrap text-danger"
+                  >
                     {form.fieldErrors.players[0]}
-                  </p>
+                  </Text>
                 )}
               </div>
               <Separator />

--- a/app/(main)/matches/[matchId]/_components/match-table/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/match-table/index.tsx
@@ -1,4 +1,4 @@
-import { cn, Separator, Surface } from "@heroui/react";
+import { cn, Separator, Surface, Text } from "@heroui/react";
 import type { CSSProperties } from "react";
 import { serverServices } from "@/lib/services/server";
 import type { MatchPlayer } from "@/lib/type";
@@ -94,9 +94,9 @@ export async function MatchTable({
         {/* ボディ */}
         <div className="grow">
           {gameRows.length === 0 && (
-            <p className="my-10 text-center text-sm text-muted">
+            <Text type="body-sm" color="muted" align="center" className="my-10">
               まだデータはありません
-            </p>
+            </Text>
           )}
           {gameRows.length > 0 &&
             gameRows.map((item, index) => (

--- a/app/(main)/matches/_components/create-match-drawer/rule-form/index.tsx
+++ b/app/(main)/matches/_components/create-match-drawer/rule-form/index.tsx
@@ -21,6 +21,7 @@ import {
   Radio,
   RadioGroup,
   Select,
+  Text,
   TextField,
   tv,
 } from "@heroui/react";
@@ -254,9 +255,9 @@ export function RuleForm({
                 </TextField>
               </FieldGroup>
               {fields.incline.errors && (
-                <p className="mt-2 text-sm text-danger">
+                <Text type="body-sm" className="mt-2 text-danger">
                   {fields.incline.errors}
-                </p>
+                </Text>
               )}
             </Fieldset>
           </div>

--- a/app/(main)/matches/_components/match-card/index.tsx
+++ b/app/(main)/matches/_components/match-card/index.tsx
@@ -1,4 +1,4 @@
-import { Card, cardVariants, Separator } from "@heroui/react";
+import { Card, cardVariants, Separator, Text } from "@heroui/react";
 import NextLink from "next/link";
 import { UserAvatar } from "@/components/user-avatar";
 import type { Match } from "@/lib/type";
@@ -21,7 +21,7 @@ export function MatchCard({ match, userId }: { match: Match; userId: string }) {
     <NextLink href={`/matches/${match.id}`} className={cardVariants().base()}>
       <Card.Header>
         <div className="flex w-full items-center justify-between">
-          <p>{displayDate}</p>
+          <Text>{displayDate}</Text>
           <div
             className="
               flex -space-x-2

--- a/app/(main)/matches/_components/player-selector/index.tsx
+++ b/app/(main)/matches/_components/player-selector/index.tsx
@@ -10,6 +10,7 @@ import {
   ListBox,
   ScrollShadow,
   SearchField,
+  Text,
 } from "@heroui/react";
 import { Check, PlusIcon } from "lucide-react";
 import { useState } from "react";
@@ -102,7 +103,9 @@ export function PlayerSelector({
     <>
       {selectedPlayers.length > 0 && (
         <div className="flex items-center gap-3">
-          <p className="mb-2 shrink-0 pl-1 text-xs text-muted">選択中</p>
+          <Text type="body-xs" color="muted" className="mb-2 shrink-0 pl-1">
+            選択中
+          </Text>
           <ScrollShadow orientation="horizontal" className="grow">
             <div className="flex gap-2 pt-2">
               {selectedPlayers.map((player) => (
@@ -130,14 +133,13 @@ export function PlayerSelector({
                       />
                     )}
                   </div>
-                  <p
-                    className="
-                      line-clamp-2 w-full text-center text-xs break-all
-                      text-foreground
-                    "
+                  <Text
+                    type="body-xs"
+                    align="center"
+                    className="line-clamp-2 w-full break-all text-foreground"
                   >
                     {player.name}
-                  </p>
+                  </Text>
                 </div>
               ))}
             </div>
@@ -145,9 +147,9 @@ export function PlayerSelector({
         </div>
       )}
       {error && (
-        <p className="mt-2 text-sm text-danger">
+        <Text type="body-sm" className="mt-2 text-danger">
           {Array.isArray(error) ? error[0] : error}
-        </p>
+        </Text>
       )}
       <SearchField
         variant="secondary"

--- a/app/(main)/matches/page.tsx
+++ b/app/(main)/matches/page.tsx
@@ -1,3 +1,4 @@
+import { Text } from "@heroui/react";
 import { serverServices } from "@/lib/services/server";
 import { CreateMatchButton } from "./_components/create-match-button";
 import { MatchCard } from "./_components/match-card";
@@ -13,11 +14,13 @@ export default async function Matches() {
   ]);
   return (
     <div>
-      <h1 className="heading-1 mb-1">成績表</h1>
+      <Text type="h1" className="heading-1 mb-1">
+        成績表
+      </Text>
       {matches.length === 0 && (
-        <p className="my-10 text-center text-sm text-muted">
+        <Text type="body-sm" color="muted" align="center" className="my-10">
           まだ成績表がありません。
-        </p>
+        </Text>
       )}
       <ul className="space-y-4">
         {matches?.map((match) => (

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -1,3 +1,4 @@
+import { Text } from "@heroui/react";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { serverServices } from "@/lib/services/server";
@@ -17,7 +18,9 @@ export default async function ProfilePage() {
 
   return (
     <div className="mx-auto max-w-md">
-      <h1 className="mx-auto mb-4 w-fit text-lg">プロフィール編集</h1>
+      <Text type="h1" className="mx-auto mb-4 w-fit text-lg">
+        プロフィール編集
+      </Text>
       <ProfileForm profile={profile} />
     </div>
   );

--- a/app/(maintenance)/maintenance/page.tsx
+++ b/app/(maintenance)/maintenance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Alert } from "@heroui/react";
+import { Alert, Text } from "@heroui/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/button";
@@ -19,7 +19,9 @@ export default function MaintenancePage() {
       </Navbar>
       <div className="flex grow items-center justify-center px-4">
         <div className="flex flex-col items-center gap-4">
-          <h1 className="text-center text-lg">メンテナンス中</h1>
+          <Text type="h1" align="center" className="text-lg">
+            メンテナンス中
+          </Text>
           <Alert status="warning">
             <Alert.Indicator />
             <Alert.Content>

--- a/components/user.tsx
+++ b/components/user.tsx
@@ -1,4 +1,4 @@
-import { cn, Skeleton } from "@heroui/react";
+import { cn, Skeleton, Text } from "@heroui/react";
 import type { ComponentPropsWithoutRef } from "react";
 import { UserAvatar } from "./user-avatar";
 
@@ -18,8 +18,14 @@ export function User({ name, displayId, avatarUrl, className }: UserProps) {
     >
       <UserAvatar avatarUrl={avatarUrl} name={name} />
       <div className="flex flex-col items-start">
-        <span className="text-sm text-inherit">{name}</span>
-        {displayId && <span className="text-xs text-muted">@{displayId}</span>}
+        <Text type="body-sm" className="text-inherit">
+          {name}
+        </Text>
+        {displayId && (
+          <Text type="body-xs" color="muted">
+            @{displayId}
+          </Text>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

素のHTML要素（`h1`〜`h6`、`p`、`span`）をHeroUI v3の`Text`コンポーネントに統一する。

## 変更内容

- 全21ファイルのテキスト要素を`<Text>`に置き換え
- `type` propでセマンティクスとスタイルを管理（`h1`〜`h6`、`body`、`body-sm`、`body-xs`）
- `color="muted"` propで`text-muted`クラスを置き換え
- `align="center"` propで`text-center`クラスを置き換え
- インライン要素（`or`、`枚`、`円`）はレイアウト破壊を避けるため`span`のまま維持
- サブコンポーネント（`Text.Heading`、`Text.Paragraph`等）は使用しない方針

## 関連

- h1が欠落しているページのissue: #1208