### PR TITLE
chore(db): drop auth.uid() column defaults (phase 2c)

### DIFF
--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -48,7 +48,7 @@ export type Database = {
         Insert: {
           created_at?: string
           friend_id: string
-          profile_id?: string
+          profile_id: string
         }
         Update: {
           created_at?: string
@@ -81,7 +81,7 @@ export type Database = {
         }
         Insert: {
           game_id: string
-          player_id?: string
+          player_id: string
           rank: number
           score: number
         }
@@ -117,7 +117,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string
-          created_by?: string
+          created_by: string
           id?: string
           match_id: string
         }
@@ -155,7 +155,7 @@ export type Database = {
           chip_count?: number | null
           match_id: string
           order?: number
-          player_id?: string
+          player_id: string
         }
         Update: {
           chip_count?: number | null
@@ -188,7 +188,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string
-          created_by?: string
+          created_by: string
           id?: string
         }
         Update: {
@@ -252,7 +252,7 @@ export type Database = {
           chip_rate: number
           crack_box_bonus: number
           created_at?: string
-          created_by?: string
+          created_by: string
           default_calc_points: number
           default_points: number
           id?: string
@@ -261,7 +261,7 @@ export type Database = {
           players_count: number
           rate: number
           updated_at?: string
-          updated_by?: string
+          updated_by: string
         }
         Update: {
           calc_method?: string

--- a/supabase/migrations/20260516121600_drop_auth_uid_defaults.sql
+++ b/supabase/migrations/20260516121600_drop_auth_uid_defaults.sql
@@ -1,0 +1,19 @@
+-- Phase 2c: remove `auth.uid()` column defaults.
+--
+-- These defaults were the last piece of the implicit assumption that
+-- `auth.uid()` is a valid profile id. The application (PR #1222) now
+-- looks up `profiles.id` via `profiles.user_id` and passes it
+-- explicitly to every INSERT, so the defaults are no longer used.
+--
+-- Note: the handle_new_user trigger still inserts `(id, user_id) =
+-- (new.id, new.id)` so the convenience invariant `profiles.id ==
+-- auth.users.id` is kept for trigger-created profiles. Decoupling the
+-- trigger as well is a separate, optional cleanup.
+
+alter table "public"."friends" alter column "profile_id" drop default;
+alter table "public"."game_players" alter column "player_id" drop default;
+alter table "public"."games" alter column "created_by" drop default;
+alter table "public"."match_players" alter column "player_id" drop default;
+alter table "public"."matches" alter column "created_by" drop default;
+alter table "public"."rules" alter column "created_by" drop default;
+alter table "public"."rules" alter column "updated_by" drop default;


### PR DESCRIPTION
## Summary

Phase 2c: 旧来の `default auth.uid()` を依存していたカラムから削除。Phase 2b (PR #1222) のアプリ修正で全 INSERT が `profiles.id` を明示的に渡すようになったため、この default は不要かつ「`auth.uid() == profile.id`」という古い仮定を隠す要因になっていた。

### 変更カラム (`alter column drop default`)

- `friends.profile_id`
- `game_players.player_id`
- `games.created_by`
- `match_players.player_id`
- `matches.created_by`
- `rules.created_by`
- `rules.updated_by`

### Scope外（意図的に残した）

- `handle_new_user` トリガーは現状維持。新規 auth ユーザー作成時に `(id, user_id) = (new.id, new.id)` で profile を作る挙動はそのまま
- トリガーを `id` 自動生成に変えると seed.sql (`profile.id = auth.users.id` 前提) も書き換えが必要になり、本PRのスコープから外れる

## ⚠️ Deploy order

このマイグレーションは **PR #1222 (Phase 2b) のアプリ本番反映が完了していること** が前提。マージ済み・本番反映済みを確認済み。

## Verification

- ✅ local Supabase で `db reset` 成功
- ✅ `pnpm test:e2e --project=chromium` 90/90 pass
- ✅ dev 環境に適用済み

## Test plan

- [ ] CI 通過
- [ ] dev で新規マッチ作成・新規ゲーム追加・フレンド追加が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)