### PR TITLE
chore(db): decouple handle_new_user from profiles.id

### DIFF
--- a/supabase/migrations/20260516122600_decouple_handle_new_user.sql
+++ b/supabase/migrations/20260516122600_decouple_handle_new_user.sql
@@ -1,0 +1,25 @@
+-- Decouple newly created profiles from auth.users.id.
+--
+-- Until now `handle_new_user` inserted `(id, user_id) = (new.id, new.id)`
+-- so the historical invariant `profiles.id == auth.users.id` was kept
+-- alive even after the schema technically supported a separation.
+--
+-- After this migration new profiles get a freshly generated
+-- `profiles.id` (via the `gen_random_uuid()` column default) and only
+-- `user_id` is tied to `auth.users.id`. The application already
+-- resolves the current profile via `profiles.user_id`, so this change
+-- has no runtime impact for users created from this point on. Existing
+-- rows are not touched.
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+begin
+  insert into public.profiles (user_id)
+  values (new.id);
+  return new;
+end;
+$function$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -135,37 +135,46 @@ INSERT INTO auth.identities (
   now(), now(), now()
 );
 
--- handle_new_user トリガーにより自動作成されたプロフィールを更新
-UPDATE public.profiles SET display_id = 'testuser', name = 'テストユーザー'
-WHERE id = '11111111-1111-1111-1111-111111111111';
-UPDATE public.profiles SET display_id = 'alice123', name = 'アリス'
-WHERE id = '22222222-2222-2222-2222-222222222222';
-UPDATE public.profiles SET display_id = 'bob123', name = 'ボブ'
-WHERE id = '33333333-3333-3333-3333-333333333333';
-UPDATE public.profiles SET display_id = 'carol123', name = 'キャロル'
-WHERE id = '44444444-4444-4444-4444-444444444444';
+-- handle_new_user トリガーで自動作成されたプロフィールに、
+-- E2E から参照できる固定 UUID とユーザー情報を設定する。
+-- profiles.id と auth.users.id は別物なので、ここで明示的に別の値を割り当てる。
+UPDATE public.profiles
+  SET id = '00000000-1111-1111-1111-111111111111', display_id = 'testuser', name = 'テストユーザー'
+WHERE user_id = '11111111-1111-1111-1111-111111111111';
+UPDATE public.profiles
+  SET id = '00000000-2222-2222-2222-222222222222', display_id = 'alice123', name = 'アリス'
+WHERE user_id = '22222222-2222-2222-2222-222222222222';
+UPDATE public.profiles
+  SET id = '00000000-3333-3333-3333-333333333333', display_id = 'bob123', name = 'ボブ'
+WHERE user_id = '33333333-3333-3333-3333-333333333333';
+UPDATE public.profiles
+  SET id = '00000000-4444-4444-4444-444444444444', display_id = 'carol123', name = 'キャロル'
+WHERE user_id = '44444444-4444-4444-4444-444444444444';
+UPDATE public.profiles
+  SET id = '00000000-5555-5555-5555-555555555555'
+WHERE user_id = '55555555-5555-5555-5555-555555555555';
 
 -- testuser のフレンドとして alice, bob, carol を登録
 -- （検索不要でデフォルトフレンド一覧から選択できるようにするため）
 INSERT INTO public.friends (profile_id, friend_id) VALUES
-  ('11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222'),
-  ('11111111-1111-1111-1111-111111111111', '33333333-3333-3333-3333-333333333333'),
-  ('11111111-1111-1111-1111-111111111111', '44444444-4444-4444-4444-444444444444');
+  ('00000000-1111-1111-1111-111111111111', '00000000-2222-2222-2222-222222222222'),
+  ('00000000-1111-1111-1111-111111111111', '00000000-3333-3333-3333-333333333333'),
+  ('00000000-1111-1111-1111-111111111111', '00000000-4444-4444-4444-444444444444');
 
 -- E2E用の事前マッチ（四麻・4人参加・ゲーム/チップ未入力）
 -- match-detail.spec.ts から直接この id に遷移して使う
 INSERT INTO public.matches (id, created_by, created_at) VALUES
   (
     'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-    '11111111-1111-1111-1111-111111111111',
+    '00000000-1111-1111-1111-111111111111',
     now()
   );
 
 INSERT INTO public.match_players (match_id, player_id, "order") VALUES
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', 0),
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '22222222-2222-2222-2222-222222222222', 1),
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '33333333-3333-3333-3333-333333333333', 2),
-  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '44444444-4444-4444-4444-444444444444', 3);
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '00000000-1111-1111-1111-111111111111', 0),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '00000000-2222-2222-2222-222222222222', 1),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '00000000-3333-3333-3333-333333333333', 2),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '00000000-4444-4444-4444-444444444444', 3);
 
 INSERT INTO public.rules (
   match_id, players_count, rate, default_points, default_calc_points,
@@ -173,21 +182,21 @@ INSERT INTO public.rules (
 ) VALUES (
   'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 4, 0, 25000, 30000,
   10000, 0, 'round', '0_0_0_0',
-  '11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111'
+  '00000000-1111-1111-1111-111111111111', '00000000-1111-1111-1111-111111111111'
 );
 
 -- E2E用の事前マッチ（三麻・3人参加・ゲーム/チップ未入力）
 INSERT INTO public.matches (id, created_by, created_at) VALUES
   (
     'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-    '11111111-1111-1111-1111-111111111111',
+    '00000000-1111-1111-1111-111111111111',
     now()
   );
 
 INSERT INTO public.match_players (match_id, player_id, "order") VALUES
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', 0),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '22222222-2222-2222-2222-222222222222', 1),
-  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '33333333-3333-3333-3333-333333333333', 2);
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '00000000-1111-1111-1111-111111111111', 0),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '00000000-2222-2222-2222-222222222222', 1),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '00000000-3333-3333-3333-333333333333', 2);
 
 INSERT INTO public.rules (
   match_id, players_count, rate, default_points, default_calc_points,
@@ -195,22 +204,22 @@ INSERT INTO public.rules (
 ) VALUES (
   'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 3, 0, 35000, 40000,
   10000, 0, 'round', '0_0_0',
-  '11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111'
+  '00000000-1111-1111-1111-111111111111', '00000000-1111-1111-1111-111111111111'
 );
 
 -- E2E用の事前マッチ（三麻ルール・4人参加=ルール人数超過・ゲーム/チップ未入力）
 INSERT INTO public.matches (id, created_by, created_at) VALUES
   (
     'cccccccc-cccc-cccc-cccc-cccccccccccc',
-    '11111111-1111-1111-1111-111111111111',
+    '00000000-1111-1111-1111-111111111111',
     now()
   );
 
 INSERT INTO public.match_players (match_id, player_id, "order") VALUES
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '11111111-1111-1111-1111-111111111111', 0),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '22222222-2222-2222-2222-222222222222', 1),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '33333333-3333-3333-3333-333333333333', 2),
-  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '44444444-4444-4444-4444-444444444444', 3);
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '00000000-1111-1111-1111-111111111111', 0),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '00000000-2222-2222-2222-222222222222', 1),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '00000000-3333-3333-3333-333333333333', 2),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '00000000-4444-4444-4444-444444444444', 3);
 
 INSERT INTO public.rules (
   match_id, players_count, rate, default_points, default_calc_points,
@@ -218,5 +227,5 @@ INSERT INTO public.rules (
 ) VALUES (
   'cccccccc-cccc-cccc-cccc-cccccccccccc', 3, 0, 35000, 40000,
   10000, 0, 'round', '0_0_0',
-  '11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111'
+  '00000000-1111-1111-1111-111111111111', '00000000-1111-1111-1111-111111111111'
 );


### PR DESCRIPTION
## Summary

新規 auth ユーザー作成時のトリガー `handle_new_user` を更新し、新規 profile の `id` を `auth.users.id` ではなく `gen_random_uuid()` で生成するように変更。`profiles.id == auth.users.id` という歴史的な暗黙の同一性を完全に断ち切る。

### 変更内容

- `handle_new_user()` を `INSERT INTO profiles (user_id) VALUES (new.id)` に変更
- これにより本マイグレーション以降に作成される profile は `id != user_id` となる
- 既存行は変更なし

### seed.sql 更新

E2E 用シードは従来 `auth.users.id` をそのまま profile.id として使っていたが、トリガー変更により profile.id がランダムになるので、トリガー実行後に明示的に固定UUID (`00000000-NNNN-...`) を割り当てる UPDATE を追加。後続の matches/match_players/friends/rules はこの固定 profile UUID を参照する。

## Verification

- ✅ local Supabase で `db reset` 成功、seed適用後の profile.id と user_id が別UUID
- ✅ `pnpm test:e2e --project=chromium` 90/90 pass
- ✅ dev 環境に適用済み

## Deploy notes

- DBのみの変更。既存ユーザーには無影響
- 本マイグレーション後に新規登録するユーザーから `profile.id != user_id` になる
- これでゲストプレイヤー実装の土台が完全に整った

🤖 Generated with [Claude Code](https://claude.com/claude-code)