### PR TITLE
Avatarの角丸をフルラウンドに固定

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,6 +16,10 @@
     @apply text-base text-muted;
   }
 
+  .avatar {
+    border-radius: calc(infinity * 1px);
+  }
+
   .avatar__fallback svg {
     @apply size-5;
   }


### PR DESCRIPTION
## 概要

HeroUIの最近のアップデートでAvatarのborder-radiusがテーマの`--radius`に追従するようになったため、Avatarが円形ではなくなっていた問題を修正。

## 変更内容

- `globals.css`でAvatarコンポーネントの`border-radius`を`calc(infinity * 1px)`（Tailwind CSS v4の`rounded-full`相当）に上書きし、常にフルラウンド（円形）で表示されるようにした

Made with [Cursor](https://cursor.com)