### PR TITLE
HeroUI v3.0.5 へアップグレード: Text → Typography リネーム

### DIFF
--- a/app/(auth)/auth-code-error/page.tsx
+++ b/app/(auth)/auth-code-error/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn, Text } from "@heroui/react";
+import { cn, Typography } from "@heroui/react";
 import NextLink from "next/link";
 import { buttonVariants } from "@/components/button";
 
@@ -10,7 +10,7 @@ import { buttonVariants } from "@/components/button";
 export default function AuthCodeErrorPage() {
   return (
     <div className="flex flex-col items-center">
-      <Text type="h1">ログインに失敗しました</Text>
+      <Typography type="h1">ログインに失敗しました</Typography>
       <NextLink className={cn(buttonVariants(), "mt-4")} href="/login">
         ログイン画面へ戻る
       </NextLink>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,4 +1,4 @@
-import { linkVariants, Separator, Text } from "@heroui/react";
+import { linkVariants, Separator, Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import NextLink from "next/link";
 import { LoginForm } from "./_components/login-form";
@@ -11,9 +11,9 @@ export const metadata: Metadata = {
 export default function LoginPage() {
   return (
     <div className="mx-auto max-w-md">
-      <Text type="h1" className="mx-auto mb-4 w-fit text-lg">
+      <Typography type="h1" className="mx-auto mb-4 w-fit text-lg">
         ログイン
-      </Text>
+      </Typography>
       <SocialProviders />
       <div className="my-4 flex items-center gap-4">
         <Separator className="shrink" />
@@ -21,12 +21,12 @@ export default function LoginPage() {
         <Separator className="shrink" />
       </div>
       <LoginForm />
-      <Text type="body-sm" align="center" className="mt-4">
+      <Typography type="body-sm" align="center" className="mt-4">
         アカウントをお持ちでない方は
         <NextLink className={linkVariants().base()} href="/sign-up">
           新規登録
         </NextLink>
-      </Text>
+      </Typography>
     </div>
   );
 }

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,4 +1,4 @@
-import { linkVariants, Text } from "@heroui/react";
+import { linkVariants, Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { serverServices } from "@/lib/services/server";
@@ -19,14 +19,14 @@ export default async function RegisterPage() {
 
   return (
     <div className="mx-auto max-w-md">
-      <Text type="h1" className="mx-auto mb-4 w-fit text-lg">
+      <Typography type="h1" className="mx-auto mb-4 w-fit text-lg">
         ユーザー情報登録
-      </Text>
-      <Text type="body-sm" color="muted" className="mb-6">
+      </Typography>
+      <Typography type="body-sm" color="muted" className="mb-6">
         ユーザーIDと名前を決めてください。
         <br />
         ユーザーIDはユーザー検索に、名前は成績表に使用されます。
-      </Text>
+      </Typography>
       <RegisterForm />
       <div className="mt-10 flex justify-center">
         <button

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,4 +1,4 @@
-import { linkVariants, Text } from "@heroui/react";
+import { linkVariants, Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import NextLink from "next/link";
 import { SignUpForm } from "./_components/sign-up-form";
@@ -10,16 +10,16 @@ export const metadata: Metadata = {
 export default function SignUpPage() {
   return (
     <div className="mx-auto max-w-md">
-      <Text type="h1" className="mx-auto mb-2 w-fit text-lg">
+      <Typography type="h1" className="mx-auto mb-2 w-fit text-lg">
         新規登録
-      </Text>
+      </Typography>
       <SignUpForm />
-      <Text type="body-sm" align="center">
+      <Typography type="body-sm" align="center">
         既にアカウントをお持ちの方は
         <NextLink className={linkVariants().base()} href="/login">
           ログイン
         </NextLink>
-      </Text>
+      </Typography>
     </div>
   );
 }

--- a/app/(lp)/page.tsx
+++ b/app/(lp)/page.tsx
@@ -1,4 +1,4 @@
-import { Card, Text } from "@heroui/react";
+import { Card, Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Logo from "@/components/logo";
@@ -164,11 +164,11 @@ export default function LandingPage() {
       {/* ヒーローセクション */}
       <section className="bg-linear-to-b from-background to-accent/10">
         <div className="z-20 container mx-auto px-4 pt-20">
-          <Text align="center" className="mb-8 text-lg">
+          <Typography align="center" className="mb-8 text-lg">
             麻雀の成績を簡単に記録・分析
             <br />
             あなたの麻雀ライフを快適に
-          </Text>
+          </Typography>
           <HeroCtaLinks />
           <div className="mx-auto mt-12 h-[480px] w-4/5 max-w-[500px]">
             <Image
@@ -185,9 +185,9 @@ export default function LandingPage() {
       <div className="container mx-auto space-y-24 px-5 py-16">
         {/* 機能紹介 */}
         <section id="features" className="">
-          <Text type="h2" align="center" className="mb-12 text-lg">
+          <Typography type="h2" align="center" className="mb-12 text-lg">
             主な機能
-          </Text>
+          </Typography>
           <div
             className="
               grid grid-cols-1 gap-8
@@ -209,9 +209,9 @@ export default function LandingPage() {
         {/* 使用方法 */}
         <section className="">
           <div className="container mx-auto">
-            <Text type="h2" align="center" className="mb-12 text-lg">
+            <Typography type="h2" align="center" className="mb-12 text-lg">
               使い方
-            </Text>
+            </Typography>
             <div
               className="
                 grid grid-cols-1 gap-8
@@ -229,10 +229,10 @@ export default function LandingPage() {
                   >
                     {step.number}
                   </div>
-                  <Text type="h3" className="mb-2 text-base">
+                  <Typography type="h3" className="mb-2 text-base">
                     {step.title}
-                  </Text>
-                  <Text>{step.description}</Text>
+                  </Typography>
+                  <Typography>{step.description}</Typography>
                 </div>
               ))}
             </div>
@@ -242,9 +242,9 @@ export default function LandingPage() {
         {/* FAQ */}
         <section className="">
           <div className="container mx-auto">
-            <Text type="h2" align="center" className="mb-12 text-lg">
+            <Typography type="h2" align="center" className="mb-12 text-lg">
               よくある質問
-            </Text>
+            </Typography>
             <Faq faqs={faqs} />
           </div>
         </section>
@@ -252,7 +252,7 @@ export default function LandingPage() {
 
       {/* フッター */}
       <footer className="bg-accent py-8 text-center text-accent-foreground">
-        <Text>&copy; 2024 Jankiroku. All rights reserved.</Text>
+        <Typography>&copy; 2024 Jankiroku. All rights reserved.</Typography>
       </footer>
     </div>
   );

--- a/app/(main)/_components/appbar/appbar-avatar/index.tsx
+++ b/app/(main)/_components/appbar/appbar-avatar/index.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, Text } from "@heroui/react";
+import { Dropdown, Typography } from "@heroui/react";
 import { UserAvatar } from "@/components/user-avatar";
 import { serverServices } from "@/lib/services/server";
 import { AppbarAvatarMenu } from "./appbar-avatar-menu";
@@ -27,12 +27,12 @@ export async function AppbarAvatar() {
           <div className="flex items-center gap-2">
             <UserAvatar avatarUrl={profile.avatarUrl} name={profile.name} />
             <div className="flex flex-col gap-0">
-              <Text type="body-sm" className="leading-5 font-medium">
+              <Typography type="body-sm" className="leading-5 font-medium">
                 {profile.name}
-              </Text>
-              <Text type="body-xs" color="muted" className="leading-none">
+              </Typography>
+              <Typography type="body-xs" color="muted" className="leading-none">
                 @{profile.displayId}
-              </Text>
+              </Typography>
             </div>
           </div>
         </div>

--- a/app/(main)/_components/release-notes/release-notes-modal/versions/0_1_0.tsx
+++ b/app/(main)/_components/release-notes/release-notes-modal/versions/0_1_0.tsx
@@ -1,14 +1,14 @@
-import { Text } from "@heroui/react";
+import { Typography } from "@heroui/react";
 import { SERVICE_NAME } from "@/lib/config";
 
 export default function ReleaseNotes_0_1_0() {
   return (
     <>
-      <Text>{SERVICE_NAME}へようこそ！</Text>
-      <Text>
+      <Typography>{SERVICE_NAME}へようこそ！</Typography>
+      <Typography>
         現在はベータ版ですが、機能の追加や改善を行っていく予定です。今後のアップデートにご期待ください！
-      </Text>
-      <Text type="h2">- 今後の機能追加予定 -</Text>
+      </Typography>
+      <Typography type="h2">- 今後の機能追加予定 -</Typography>
       <ol className="list-inside list-disc">
         <li>半荘結果編集</li>
         <li>ユーザー情報編集</li>

--- a/app/(main)/_components/release-notes/release-notes-modal/versions/0_1_1.tsx
+++ b/app/(main)/_components/release-notes/release-notes-modal/versions/0_1_1.tsx
@@ -1,9 +1,9 @@
-import { Text } from "@heroui/react";
+import { Typography } from "@heroui/react";
 
 export default function ReleaseNotes_0_1_0() {
   return (
     <>
-      <Text type="h2">Version 0.1.1</Text>
+      <Typography type="h2">Version 0.1.1</Typography>
       <ol className="list-inside list-disc">
         <li>ゲーム結果削除機能追加</li>
         <li>ゲーム入力において一部端末で画面が拡大してしまう問題の修正</li>

--- a/app/(main)/friends/add/page.tsx
+++ b/app/(main)/friends/add/page.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@heroui/react";
+import { Typography } from "@heroui/react";
 import { Suspense } from "react";
 import { User } from "@/components/user";
 import { serverServices } from "@/lib/services/server";
@@ -23,18 +23,23 @@ export default async function AddFriendPage({
     <div>
       <div className="mb-4 flex items-center gap-1">
         <BackButton />
-        <Text type="h1" className="heading-1">
+        <Typography type="h1" className="heading-1">
           フレンド追加
-        </Text>
+        </Typography>
       </div>
       <Suspense>
         <FriendSearch defaultValue={query ?? ""} />
       </Suspense>
       <ul className="mt-1">
         {!!query && players.length === 0 && (
-          <Text type="body-sm" color="muted" align="center" className="mt-10">
+          <Typography
+            type="body-sm"
+            color="muted"
+            align="center"
+            className="mt-10"
+          >
             見つかりませんでした
-          </Text>
+          </Typography>
         )}
         {players.map(({ id, name, displayId, avatarUrl }) => (
           <li key={id} className="flex items-center justify-between py-2">

--- a/app/(main)/friends/loading.tsx
+++ b/app/(main)/friends/loading.tsx
@@ -1,13 +1,13 @@
-import { Text } from "@heroui/react";
+import { Typography } from "@heroui/react";
 import { UserSkeleton } from "@/components/user";
 
 export default function FriendsLoading() {
   return (
     <div>
       <div className="mb-4 flex h-10 items-center justify-between">
-        <Text type="h1" className="heading-1">
+        <Typography type="h1" className="heading-1">
           フレンド
-        </Text>
+        </Typography>
       </div>
       <ul className="space-y-1">
         {Array.from({ length: 3 }, (_, i) => `skeleton-${i}`).map((id) => (

--- a/app/(main)/friends/page.tsx
+++ b/app/(main)/friends/page.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@heroui/react";
+import { Typography } from "@heroui/react";
 import { User } from "@/components/user";
 import { serverServices } from "@/lib/services/server";
 import { AddButton } from "./_components/add-button";
@@ -12,9 +12,9 @@ export default async function FriendsPage() {
   return (
     <div>
       <div className="mb-4 flex items-center justify-between">
-        <Text type="h1" className="heading-1">
+        <Typography type="h1" className="heading-1">
           フレンド
-        </Text>
+        </Typography>
         <AddButton />
       </div>
       <ul className="space-y-1">

--- a/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
@@ -6,8 +6,8 @@ import {
   FieldError,
   InputGroup,
   Label,
-  Text,
   TextField,
+  Typography,
 } from "@heroui/react";
 import { useActionState } from "react";
 import { Button } from "@/components/button";
@@ -126,9 +126,12 @@ export function ChipForm({
           })}
         </ul>
         {form.errors && (
-          <Text type="body-xs" className="whitespace-pre-wrap text-danger">
+          <Typography
+            type="body-xs"
+            className="whitespace-pre-wrap text-danger"
+          >
             {form.errors}
-          </Text>
+          </Typography>
         )}
       </Drawer.Body>
       <Drawer.Footer>

--- a/app/(main)/matches/[matchId]/_components/create-game-drawer/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/create-game-drawer/index.tsx
@@ -11,8 +11,8 @@ import {
   ListBox,
   Select,
   Separator,
-  Text,
   TextField,
+  Typography,
 } from "@heroui/react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useActionState } from "react";
@@ -227,12 +227,12 @@ export function CreateGameDrawer({
                   })}
                 </ul>
                 {form.fieldErrors?.players?.[0] && (
-                  <Text
+                  <Typography
                     type="body-xs"
                     className="mt-1 whitespace-pre-wrap text-danger"
                   >
                     {form.fieldErrors.players[0]}
-                  </Text>
+                  </Typography>
                 )}
               </div>
               <Separator />

--- a/app/(main)/matches/[matchId]/_components/match-table/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/match-table/index.tsx
@@ -1,4 +1,4 @@
-import { cn, Separator, Surface, Text } from "@heroui/react";
+import { cn, Separator, Surface, Typography } from "@heroui/react";
 import type { CSSProperties } from "react";
 import { serverServices } from "@/lib/services/server";
 import type { MatchPlayer } from "@/lib/type";
@@ -89,9 +89,14 @@ export async function MatchTable({
         {/* ボディ */}
         <div className="grow">
           {gameRows.length === 0 && (
-            <Text type="body-sm" color="muted" align="center" className="my-10">
+            <Typography
+              type="body-sm"
+              color="muted"
+              align="center"
+              className="my-10"
+            >
               まだデータはありません
-            </Text>
+            </Typography>
           )}
           {gameRows.length > 0 &&
             gameRows.map((item, index) => (

--- a/app/(main)/matches/_components/create-match-drawer/rule-form/index.tsx
+++ b/app/(main)/matches/_components/create-match-drawer/rule-form/index.tsx
@@ -21,8 +21,8 @@ import {
   Radio,
   RadioGroup,
   Select,
-  Text,
   TextField,
+  Typography,
   tv,
 } from "@heroui/react";
 import { useRef } from "react";
@@ -255,9 +255,9 @@ export function RuleForm({
                 </TextField>
               </FieldGroup>
               {fields.incline.errors && (
-                <Text type="body-sm" className="mt-2 text-danger">
+                <Typography type="body-sm" className="mt-2 text-danger">
                   {fields.incline.errors}
-                </Text>
+                </Typography>
               )}
             </Fieldset>
           </div>

--- a/app/(main)/matches/_components/match-card/index.tsx
+++ b/app/(main)/matches/_components/match-card/index.tsx
@@ -1,4 +1,4 @@
-import { Card, cardVariants, Separator, Text } from "@heroui/react";
+import { Card, cardVariants, Separator, Typography } from "@heroui/react";
 import NextLink from "next/link";
 import { UserAvatar } from "@/components/user-avatar";
 import type { Match } from "@/lib/type";
@@ -21,7 +21,7 @@ export function MatchCard({ match, userId }: { match: Match; userId: string }) {
     <NextLink href={`/matches/${match.id}`} className={cardVariants().base()}>
       <Card.Header>
         <div className="flex w-full items-center justify-between">
-          <Text>{displayDate}</Text>
+          <Typography>{displayDate}</Typography>
           <div
             className="
               flex -space-x-2

--- a/app/(main)/matches/_components/player-selector/index.tsx
+++ b/app/(main)/matches/_components/player-selector/index.tsx
@@ -10,7 +10,7 @@ import {
   ListBox,
   ScrollShadow,
   SearchField,
-  Text,
+  Typography,
 } from "@heroui/react";
 import { Check, PlusIcon } from "lucide-react";
 import { useState } from "react";
@@ -101,9 +101,13 @@ export function PlayerSelector({
     <>
       {selectedPlayers.length > 0 && (
         <div className="flex items-center gap-3">
-          <Text type="body-xs" color="muted" className="mb-2 shrink-0 pl-1">
+          <Typography
+            type="body-xs"
+            color="muted"
+            className="mb-2 shrink-0 pl-1"
+          >
             選択中
-          </Text>
+          </Typography>
           <ScrollShadow orientation="horizontal" className="grow">
             <div className="flex gap-2 pt-2">
               {selectedPlayers.map((player) => (
@@ -131,13 +135,13 @@ export function PlayerSelector({
                       />
                     )}
                   </div>
-                  <Text
+                  <Typography
                     type="body-xs"
                     align="center"
                     className="line-clamp-2 w-full break-all text-foreground"
                   >
                     {player.name}
-                  </Text>
+                  </Typography>
                 </div>
               ))}
             </div>
@@ -145,9 +149,9 @@ export function PlayerSelector({
         </div>
       )}
       {error && (
-        <Text type="body-sm" className="mt-2 text-danger">
+        <Typography type="body-sm" className="mt-2 text-danger">
           {Array.isArray(error) ? error[0] : error}
-        </Text>
+        </Typography>
       )}
       <SearchField
         variant="secondary"

--- a/app/(main)/matches/page.tsx
+++ b/app/(main)/matches/page.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@heroui/react";
+import { Typography } from "@heroui/react";
 import { serverServices } from "@/lib/services/server";
 import { CreateMatchButton } from "./_components/create-match-button";
 import { MatchCard } from "./_components/match-card";
@@ -14,13 +14,18 @@ export default async function Matches() {
   ]);
   return (
     <div>
-      <Text type="h1" className="heading-1 mb-1">
+      <Typography type="h1" className="heading-1 mb-1">
         成績表
-      </Text>
+      </Typography>
       {matches.length === 0 && (
-        <Text type="body-sm" color="muted" align="center" className="my-10">
+        <Typography
+          type="body-sm"
+          color="muted"
+          align="center"
+          className="my-10"
+        >
           まだ成績表がありません。
-        </Text>
+        </Typography>
       )}
       <ul className="space-y-4">
         {matches?.map((match) => (

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@heroui/react";
+import { Typography } from "@heroui/react";
 import type { Metadata } from "next";
 import { serverServices } from "@/lib/services/server";
 import { ProfileForm } from "./_components/profile-form";
@@ -13,9 +13,9 @@ export default async function ProfilePage() {
 
   return (
     <div className="mx-auto max-w-md">
-      <Text type="h1" className="mx-auto mb-4 w-fit text-lg">
+      <Typography type="h1" className="mx-auto mb-4 w-fit text-lg">
         プロフィール編集
-      </Text>
+      </Typography>
       <ProfileForm profile={profile} />
     </div>
   );

--- a/app/(maintenance)/maintenance/page.tsx
+++ b/app/(maintenance)/maintenance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Alert, Text } from "@heroui/react";
+import { Alert, Typography } from "@heroui/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/button";
@@ -19,9 +19,9 @@ export default function MaintenancePage() {
       </Navbar>
       <div className="flex grow items-center justify-center px-4">
         <div className="flex flex-col items-center gap-4">
-          <Text type="h1" align="center" className="text-lg">
+          <Typography type="h1" align="center" className="text-lg">
             メンテナンス中
-          </Text>
+          </Typography>
           <Alert status="warning">
             <Alert.Indicator />
             <Alert.Content>

--- a/components/user.tsx
+++ b/components/user.tsx
@@ -1,4 +1,4 @@
-import { cn, Skeleton, Text } from "@heroui/react";
+import { cn, Skeleton, Typography } from "@heroui/react";
 import type { ComponentPropsWithoutRef } from "react";
 import { UserAvatar } from "./user-avatar";
 
@@ -18,13 +18,13 @@ export function User({ name, displayId, avatarUrl, className }: UserProps) {
     >
       <UserAvatar avatarUrl={avatarUrl} name={name} />
       <div className="flex flex-col items-start">
-        <Text type="body-sm" className="text-inherit">
+        <Typography type="body-sm" className="text-inherit">
           {name}
-        </Text>
+        </Typography>
         {displayId && (
-          <Text type="body-xs" color="muted">
+          <Typography type="body-xs" color="muted">
             @{displayId}
-          </Text>
+          </Typography>
         )}
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@conform-to/react": "1.19.3",
         "@conform-to/zod": "1.19.3",
-        "@heroui/react": "3.0.4",
-        "@heroui/styles": "3.0.4",
+        "@heroui/react": "3.0.5",
+        "@heroui/styles": "3.0.5",
         "@iconify/react": "6.0.2",
         "@supabase/ssr": "0.10.3",
         "@supabase/supabase-js": "2.106.0",
@@ -186,9 +186,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -206,9 +203,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -226,9 +220,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -246,9 +237,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1158,12 +1146,12 @@
       }
     },
     "node_modules/@heroui/react": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@heroui/react/-/react-3.0.4.tgz",
-      "integrity": "sha512-6y6aXZ9v8W/dNDKA3yP0+VnY3OQUeg8164YnOXVaFd1U8+WbXka1hwPgi3PK/qmMv8W81SdiVnmEZUXjHbXpfw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@heroui/react/-/react-3.0.5.tgz",
+      "integrity": "sha512-kBb3aUcSAJOraPOb2MbOS1yNUcSCc6vnl0zTtzuWvJZabWgSff5Y9FNyXNjk/d56vm2ermfXa/gfBYqTUtRTzA==",
       "license": "MIT",
       "dependencies": {
-        "@heroui/styles": "3.0.4",
+        "@heroui/styles": "3.0.5",
         "@radix-ui/react-avatar": "1.1.11",
         "@react-aria/i18n": "3.13.0",
         "@react-aria/ssr": "3.10.0",
@@ -1183,9 +1171,9 @@
       }
     },
     "node_modules/@heroui/styles": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@heroui/styles/-/styles-3.0.4.tgz",
-      "integrity": "sha512-3zi0cu8PPmMbUdRg7AO486w9uA7ZHuV6m8ab23RQHChJ97q3s/tM13r74l7A963Dif+0ZWpQRiicsUvWuaAcDg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@heroui/styles/-/styles-3.0.5.tgz",
+      "integrity": "sha512-5DI5sa7GGe1Uw8PCBhooAIGoqZbcR0ilamPjzgv94qVgolGs9+FqbeNp2bcbyoHJn9+HLKQMYiIa44LwH0VLww==",
       "license": "MIT",
       "dependencies": {
         "tailwind-variants": "3.2.2",
@@ -1374,9 +1362,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1392,9 +1377,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1412,9 +1394,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1430,9 +1409,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1450,9 +1426,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1468,9 +1441,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1488,9 +1458,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1507,9 +1474,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1525,9 +1489,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1551,9 +1512,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1575,9 +1533,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1601,9 +1556,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1625,9 +1577,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1651,9 +1600,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1676,9 +1622,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1700,9 +1643,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1941,9 +1881,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1959,9 +1896,6 @@
       "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1979,9 +1913,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,9 +1928,6 @@
       "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2502,9 +2430,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2522,9 +2447,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2542,9 +2464,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2562,9 +2481,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2582,9 +2498,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2602,9 +2515,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2782,9 +2692,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2799,9 +2706,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2816,9 +2720,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2833,9 +2734,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3088,9 +2986,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3106,9 +3001,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3126,9 +3018,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3144,9 +3033,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5531,9 +5417,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5553,9 +5436,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5577,9 +5457,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5599,9 +5476,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "dependencies": {
     "@conform-to/react": "1.19.3",
     "@conform-to/zod": "1.19.3",
-    "@heroui/react": "3.0.4",
-    "@heroui/styles": "3.0.4",
+    "@heroui/react": "3.0.5",
+    "@heroui/styles": "3.0.5",
     "@iconify/react": "6.0.2",
     "@supabase/ssr": "0.10.3",
     "@supabase/supabase-js": "2.106.0",


### PR DESCRIPTION
## 概要

- HeroUI を v3.0.4 → v3.0.5 にアップグレード
- Breaking Change に伴い、全ファイルの `Text` コンポーネントを `Typography` にリネーム

## 変更内容

- `@heroui/react` と `@heroui/styles` を 3.0.5 にアップデート
- 全 21 ファイルの `Text` → `Typography` リネーム（import + JSX）

## 背景

HeroUI v3.0.4 の `Text` コンポーネントは BEM クラス名（`text--body-sm`, `text--color-muted`, `text--align-center` など）が Tailwind の `text-*` ユーティリティと衝突し、`tailwind-merge` がバリアントクラスを重複排除して**サイレントに削除**していました。これにより `align`, `color`, `weight` などの props が一切機能しない状態でした。

v3.0.5 ではブロック名が `typography` にリネームされ、この衝突が恒久的に解消されています。


Made with [Cursor](https://cursor.com)