### PR TITLE
チップ入力フォームのバリデーションエラーが表示されないバグを修正

### DIFF
--- a/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
+++ b/app/(main)/matches/[matchId]/_components/chip-drawer/chip-form/index.tsx
@@ -125,12 +125,12 @@ export function ChipForm({
             );
           })}
         </ul>
-        {form.errors && (
+        {fields.playerChip.errors && (
           <Typography
             type="body-xs"
             className="whitespace-pre-wrap text-danger"
           >
-            {form.errors}
+            {fields.playerChip.errors}
           </Typography>
         )}
       </Drawer.Body>

--- a/e2e/match-detail.spec.ts
+++ b/e2e/match-detail.spec.ts
@@ -392,7 +392,9 @@ test.describe("チップ入力フォーム (4人)", () => {
     }
   });
 
-  test("チップ合計が0以外だとドロワーが閉じない", async ({ page }) => {
+  test("チップ合計が0以外だとエラーメッセージが表示される", async ({
+    page,
+  }) => {
     await openDrawer(page);
 
     await page.getByRole("spinbutton", { name: TEST_USERS.me.name }).fill("5");
@@ -411,6 +413,9 @@ test.describe("チップ入力フォーム (4人)", () => {
     // 合計5 ≠ 0 のためエラー、ドロワーは閉じない
     await expect(
       page.getByRole("dialog", { name: "チップ入力" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/チップの合計が0枚になるように入力してください/),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## 概要

チップ入力フォームで合計が0枚にならない場合、保存ボタンを押してもエラーメッセージが表示されないバグを修正しました。

## 変更内容

- `ChipForm`コンポーネントのエラー表示を`form.errors`（フォームレベル）から`fields.playerChip.errors`（フィールドレベル）に修正
  - スキーマのバリデーションエラーは`path: ["playerChip"]`でフィールドレベルに発行されるため、`form.errors`には反映されていなかった
  - `CreateGameDrawer`の`form.fieldErrors?.players?.[0]`と同じパターンに統一
- e2eテストを更新し、エラーメッセージが実際に表示されることを検証するアサーションを追加

Made with [Cursor](https://cursor.com)